### PR TITLE
[WIP] Solr 5.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies := {
   }
 }
 
-val solrVersion = "5.0.0"
+val solrVersion = "5.5.1"
 val slf4jVersion = "1.7.14"
 val tomcatVersion = "7.0.67"
 

--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -243,7 +243,7 @@ class AsyncSolrClient private (val loadBalancer: LoadBalancer,
     val promise = scala.concurrent.promise[QueryResponse]
     val startTime = System.currentTimeMillis()
 
-    val url = solrServer.baseUrl + getPath(q) + ClientUtils.toQueryString(wparams, false)
+    val url = solrServer.baseUrl + getPath(q) + wparams.toQueryString
     val request = httpClient.prepareGet(url).addHeader("User-Agent", AGENT).build()
 
     try {

--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -274,16 +274,11 @@ object CloudSolrServers {
     }
   }
 
-  private def serverStatus(replica: Replica): ServerStatus = replica.get(ZkStateReader.STATE_PROP) match {
-    case ZkStateReader.ACTIVE => Enabled
-    case ZkStateReader.RECOVERING => Disabled
-    case ZkStateReader.RECOVERY_FAILED => Failed
-    case ZkStateReader.DOWN => Failed
-    case default =>
-      // E.g. there's SYNC, which *should* not be used according to http://markmail.org/message/wt54x2xisileyeoo, but
-      // we should at log unknown states and handle them as Failed.
-      logger.warn(s"Unknown state $default, translating to 'Failed' for now...")
-      Failed
+  private def serverStatus(replica: Replica): ServerStatus = replica.getState match {
+    case Replica.State.ACTIVE => Enabled
+    case Replica.State.RECOVERING => Disabled
+    case Replica.State.RECOVERY_FAILED => Failed
+    case Replica.State.DOWN => Failed
   }
 
   /**


### PR DESCRIPTION
Solr 5.5.1 is the most recent version of the 5.x branch. For reasons outside my control, I'm unable to use Solr 5.0 or 6, so I've provided fixes here to update `solrs` to use Solr 5.5 instead.

#### Testing
I'm testing with a Solr 5.5 docker image. It can be set up with:
```console
docker pull solr:5.5
docker run --name solrs_test -d -p 8983:8983 -t solr:5.5
docker exec -it --user=solr solrs_test bin/solr create_core -c collection1
```
`sbt test` will succeed at compiling, and past most tests. I don't unfortunately have a SolrCloud/Zookeeper setup, so I expected those tests to fail. Here are the results on my machine:
```console
[info] Run completed in 23 seconds, 307 milliseconds.
[info] Total number of tests run: 52
[info] Suites: completed 10, aborted 3
[info] Tests: succeeded 47, failed 5, canceled 0, ignored 0, pending 0
[info] *** 3 SUITES ABORTED ***
[info] *** 5 TESTS FAILED ***
[error] Failed tests:
[error] 	io.ino.solrs.PingStatusObserverIntegrationSpec
[error] 	io.ino.solrs.CloudSolrServersUninitializedIntegrationSpec
[error] Error during tests:
[error] 	io.ino.solrs.CloudSolrServersIntegrationSpec
[error] 	io.ino.solrs.AsyncSolrClientIntegrationSpec
[error] 	io.ino.solrs.AsyncSolrClientCloudIntegrationSpec
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 24 s, completed Jun 24, 2016 12:57:23 PM
```
Are these failures "okay" given that I don't have a cloud setup?