### PR TITLE
issue 25 - Query method POST, double sending all params

### DIFF
--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -3,6 +3,7 @@ package io.ino.solrs
 import java.util.Arrays.asList
 
 import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.SolrRequest.METHOD.POST
 import org.apache.solr.client.solrj.beans.Field
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -180,6 +181,24 @@ class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
       docs.asScala should be (empty)
     }
 
+    it("should pass same query parameters") {
+      // POST method should pass parameters exactly once, not twice.
+      // check this via response header's parameter echo (params field)
+      val query = new SolrQuery("cat:cat1")
+      val paramEchoExpected = {
+        solr.query(query, POST).getHeader.get("params")
+      }
+      val paramEcho = await(solrs.query(query, POST)).getHeader.get("params")
+      paramEcho.equals(paramEchoExpected) should be (true)
+    }
+
+    it("should pass same query parameters in post and get") {
+      // Post query and Get query should pass exactly the same set of parameters to Solr.
+      val query = new SolrQuery("cat:cat1")
+      val paramEchoGet = await(solrs.query(query)).getHeader.get("params")
+      val paramEchoPost = await(solrs.query(query, POST)).getHeader.get("params")
+      paramEchoPost.equals(paramEchoGet) should be (true)
+    }
   }
 
 }

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -189,7 +189,7 @@ class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
         solr.query(query, POST).getHeader.get("params")
       }
       val paramEcho = await(solrs.query(query, POST)).getHeader.get("params")
-      paramEcho.equals(paramEchoExpected) should be (true)
+      paramEcho should be (paramEchoExpected)
     }
 
     it("should pass same query parameters in post and get") {
@@ -197,7 +197,7 @@ class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
       val query = new SolrQuery("cat:cat1")
       val paramEchoGet = await(solrs.query(query)).getHeader.get("params")
       val paramEchoPost = await(solrs.query(query, POST)).getHeader.get("params")
-      paramEchoPost.equals(paramEchoGet) should be (true)
+      paramEchoPost should be (paramEchoGet)
     }
   }
 


### PR DESCRIPTION
This is a very simple patch for issue #25.  

- AsyncSolrClient URL forming code has a bug that duplicates parameters twice when working with POST method (parameters is Form data as expected, but also once more in the URL).
- Patched this by making URL without wparam values, for POST (non-stream POST) case. This is the expected behavior, and the same to corresponding SolrJ part.

How to verify it works? 
- Make a search query via post method. Without this patch, all query parameters appear twice in the Solr server side. Depending on query parser, this could make exceptions and break query (e.g. MoreLikeThis) With this patch, parameters are no longer duplicated with POST method.
