### PR TITLE
Remove akka dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ libraryDependencies ++= Seq(
   "org.apache.solr"         % "solr-solrj"        % solrVersion,
   "org.asynchttpclient"     % "async-http-client" % "2.0.32",
   "org.scala-lang.modules" %% "scala-xml"         % "1.0.6",
+  "org.scala-lang.modules" %% "scala-java8-compat"% "0.8.0",
   "io.dropwizard.metrics"   % "metrics-core"      % "3.2.2" % "optional",
   "org.slf4j"               % "slf4j-api"         % slf4jVersion,
   "com.typesafe.akka"      %% "akka-actor"        % "2.4.19",

--- a/src/main/scala/io/ino/solrs/ServerStateObserver.scala
+++ b/src/main/scala/io/ino/solrs/ServerStateObserver.scala
@@ -1,7 +1,8 @@
 package io.ino.solrs
 
-import akka.actor.ActorSystem
-import org.asynchttpclient.{Response, AsyncCompletionHandler, AsyncHttpClient}
+import java.util.concurrent.ScheduledExecutorService
+
+import org.asynchttpclient.{AsyncCompletionHandler, AsyncHttpClient, Response}
 import io.ino.solrs.future.{Future, FutureFactory, ScalaFutureFactory}
 import org.slf4j.LoggerFactory
 
@@ -21,12 +22,12 @@ trait ServerStateObserver[F[_]] {
  * Configuration for scheduled server state observation.
  * @param serverStateObserver the observer that checks server state
  * @param checkInterval the interval to check server state
- * @param actorSystem used for scheduling
+ * @param executorService the scheduler used to poll for state changes
  * @param futureFactory factory to create promise/future types.
  */
 case class ServerStateObservation[F[_]](serverStateObserver: ServerStateObserver[F],
                                   checkInterval: FiniteDuration,
-                                  actorSystem: ActorSystem,
+                                  executorService: ScheduledExecutorService,
                                   futureFactory: FutureFactory[F])
 
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -1,6 +1,7 @@
 package io.ino.solrs
 
 import java.util.Arrays.asList
+import java.util.concurrent.Executors
 
 import akka.actor.ActorSystem
 import org.asynchttpclient.DefaultAsyncHttpClient
@@ -68,7 +69,7 @@ class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
       val solr = AsyncSolrClient.Builder(new SingleServerLB(solrUrl)).withServerStateObservation(
         new PingStatusObserver(solrServers, httpClient),
         20 millis,
-        ActorSystem("test-actorsystem")
+        Executors.newSingleThreadScheduledExecutor()
       ).build
 
       enable(solrUrl)


### PR DESCRIPTION
Motivation: I don't want to depend on akka for something the jdk can do without any additional dependencies. WDYT?

I'll rebase if you're ok with https://github.com/inoio/solrs/pull/32.