### PR TITLE
Cleanup warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,15 @@ scalaVersion := "2.11.12"
 
 crossScalaVersions := Seq("2.11.12", "2.12.6")
 
-scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
+scalacOptions ++= Seq(
+  "-unchecked",
+  "-deprecation",
+  "-feature",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-language:postfixOps"
+)
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 

--- a/src/main/scala/io/ino/concurrent/Execution.scala
+++ b/src/main/scala/io/ino/concurrent/Execution.scala
@@ -4,7 +4,7 @@ import scala.concurrent.ExecutionContext
 
 object Execution {
 
-  val sameThreadContext = new ExecutionContext {
+  val sameThreadContext: ExecutionContext = new ExecutionContext {
     def reportFailure(t: Throwable) { t.printStackTrace() }
     def execute(runnable: Runnable) {runnable.run()}
   }
@@ -13,7 +13,7 @@ object Execution {
     /**
      * Runs in the caller's thread.
      */
-    implicit val sameThreadContext = Execution.sameThreadContext
+    implicit val sameThreadContext: ExecutionContext = Execution.sameThreadContext
   }
 
 }

--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -52,8 +52,6 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
-import scala.language.higherKinds
-import scala.language.postfixOps
 import scala.util.control.NonFatal
 
 object AsyncSolrClient {

--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -1,6 +1,6 @@
 package io.ino.solrs
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
+import java.io.{ByteArrayInputStream, IOException}
 import java.util.Arrays.asList
 import java.util.Locale
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
@@ -54,6 +54,7 @@ import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
+//noinspection ConvertibleToMethodValue
 object AsyncSolrClient {
 
   /* The function that creates that actual instance of AsyncSolrClient */
@@ -186,9 +187,9 @@ object AsyncSolrClient {
 }
 
 /**
-  * Async, non-blocking Solr Server that allows to make requests to Solr.
-  * The usage shall be similar to the <a href="https://wiki.apache.org/solr/Solrj">solrj SolrServer</a>,
-  * so request returns a future of a {@link SolrResponse}.
+  * Async, non-blocking Solr Client that allows to make requests to Solr.
+  * The usage shall be similar to the <a href="https://wiki.apache.org/solr/Solrj">solrj SolrClient</a>,
+  * so request returns a future of a [[org.apache.solr.client.solrj.SolrResponse SolrResponse]].
   *
   * @author <a href="martin.grotzke@inoio.de">Martin Grotzke</a>
   */
@@ -208,9 +209,9 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   /**
    * User-Agent String.
    */
-  val AGENT = "Solr[" + classOf[AsyncSolrClient[F]].getName() + "] 1.0"
+  private val agent = "Solr[" + classOf[AsyncSolrClient[F]].getName + "] 1.0"
 
-  private val logger = LoggerFactory.getLogger(getClass())
+  private val logger = LoggerFactory.getLogger(getClass)
 
   private val cancellableObservation = serverStateObservation.map { observation =>
     val task: Runnable = new Runnable() {
@@ -283,7 +284,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param collection     the Solr collection to add documents to
     * @param docs           the collection of documents
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(collection: Option[String] = None, docs: Iterable[SolrInputDocument], commitWithinMs: Int = -1): F[UpdateResponse] =
     execute(updateRequest(collection, commitWithinMs).add(docs.asJavaCollection))
@@ -293,7 +294,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     *
     * @param collection  the Solr collection to add documents to
     * @param docIterator the iterator which returns SolrInputDocument instances
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(collection: String, docIterator: Iterator[SolrInputDocument]): F[UpdateResponse] = {
     val req = updateRequest(Some(collection))
@@ -305,7 +306,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * Adds the documents supplied by the given iterator.
     *
     * @param docIterator the iterator which returns SolrInputDocument instances
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(docIterator: Iterator[SolrInputDocument]): F[UpdateResponse] = {
     val req = updateRequest(None)
@@ -319,32 +320,32 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param collection     the Solr collection to add the document to
     * @param doc            the input document
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDoc(collection: Option[String] = None, doc: SolrInputDocument, commitWithinMs: Int = -1): F[UpdateResponse] =
     execute(updateRequest(collection, commitWithinMs).add(doc))
 
   /**
     * Adds a single bean specifying max time before it becomes committed
-    * The bean is converted to a {@link SolrInputDocument} by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The bean is converted to a [[org.apache.solr.common.SolrInputDocument SolrInputDocument]] by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection to Solr collection to add documents to
     * @param obj        the input bean
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBean(collection: Option[String] = None, obj: Any, commitWithinMs: Int = -1): F[UpdateResponse] =
     addDoc(collection, binder.toSolrInputDocument(obj), commitWithinMs)
 
   /**
     * Adds a collection of beans specifying max time before they become committed
-    * The beans are converted to {@link SolrInputDocument}s by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The beans are converted to [[org.apache.solr.common.SolrInputDocument SolrInputDocument]]s by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection     the Solr collection to add documents to
     * @param beans          the collection of beans
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(collection: Option[String] = None, beans: Iterable[_], commitWithinMs: Int = -1): F[UpdateResponse] =
     addDocs(collection, beans.map(binder.toSolrInputDocument), commitWithinMs)
@@ -354,7 +355,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     *
     * @param collection   the Solr collection to add the documents to
     * @param beanIterator the iterator which returns Beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(collection: String, beanIterator: Iterator[_]): F[UpdateResponse] =
     addDocs(collection, beanIterator.map(binder.toSolrInputDocument))
@@ -363,7 +364,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * Adds the beans supplied by the given iterator.
     *
     * @param beanIterator the iterator which returns Beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(beanIterator: Iterator[_]): F[UpdateResponse] =
     addDocs(beanIterator.map(binder.toSolrInputDocument))
@@ -377,7 +378,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     *                     main query searcher, making the changes visible
     * @param softCommit   makes index changes visible while neither fsync-ing index files
     *                     nor writing a new index descriptor
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(collection: Option[String] = None, waitFlush: Boolean = true, waitSearcher: Boolean = true, softCommit: Boolean = false): F[UpdateResponse] =
@@ -392,7 +393,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param waitSearcher block until a new searcher is opened and registered as
     *                     the main query searcher, making the changes visible
     * @param maxSegments  optimizes down to at most this number of segments
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(collection: Option[String] = None, waitFlush: Boolean = true, waitSearcher: Boolean = true, maxSegments: Int = 1): F[UpdateResponse] =
@@ -405,7 +406,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * a commit etc.
     *
     * @param collection the Solr collection to send the rollback to
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def rollback(collection: Option[String] = None): F[UpdateResponse] =
@@ -417,7 +418,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param collection     the Solr collection to delete the document from
     * @param id             the ID of the document to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteById(collection: Option[String] = None, id: String, commitWithinMs: Int = -1): F[UpdateResponse] =
@@ -429,7 +430,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param collection     the Solr collection to delete the documents from
     * @param ids            the list of document IDs to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByIds(collection: Option[String] = None, ids: Seq[String], commitWithinMs: Int = -1): F[UpdateResponse] =
@@ -441,7 +442,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     * @param collection     the Solr collection to delete the documents from
     * @param query          the query expressing what documents to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByQuery(collection: Option[String] = None, query: String, commitWithinMs: Int = -1): F[UpdateResponse] =
@@ -588,7 +589,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   }
 
   private def execute[T <: SolrResponse : SolrResponseFactory](solrServer: SolrServer, r: SolrRequest[_ <: T]): Future[T] = {
-    val monitoredRequest = loadBalancer.interceptRequest[T](doExecute[T] _) _
+    val monitoredRequest = loadBalancer.interceptRequest[T](doExecute[T]) _
     requestInterceptor.map(ri =>
       ri.interceptRequest[T](monitoredRequest)(solrServer, r)
     ).getOrElse(monitoredRequest(solrServer, r))
@@ -596,13 +597,13 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
 
   private[solrs] def doExecute[T <: SolrResponse : SolrResponseFactory](solrServer: SolrServer, r: SolrRequest[_ <: T]): Future[T] = {
 
-    val wparams = new ModifiableSolrParams(r.getParams())
+    val wparams = new ModifiableSolrParams(r.getParams)
     if (responseParser != null) {
-      wparams.set(CommonParams.WT, responseParser.getWriterType())
-      wparams.set(CommonParams.VERSION, responseParser.getVersion())
+      wparams.set(CommonParams.WT, responseParser.getWriterType)
+      wparams.set(CommonParams.VERSION, responseParser.getVersion)
     }
 
-    implicit val s = solrServer
+    implicit val s: SolrServer = solrServer
 
     val promise = futureFactory.newPromise[T]
     val startTime = System.currentTimeMillis()
@@ -637,7 +638,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
         req.setFormParams(wparams.getMap.asScala.mapValues(asList[String](_: _*)).asJava)
       }
     }
-    val request = requestBuilder.addHeader("User-Agent", AGENT).build()
+    val request = requestBuilder.addHeader("User-Agent", agent).build()
 
     try {
       httpClient.executeRequest(request, new AsyncCompletionHandler[Response]() {
@@ -676,15 +677,15 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
 
     validateResponse(response, responseParser)
 
-    val httpStatus = response.getStatusCode()
+    val httpStatus = response.getStatusCode
 
     try {
       val charset = getContentCharSet(response.getContentType).orNull
-      rsp = responseParser.processResponse(response.getResponseBodyAsStream(), charset)
+      rsp = responseParser.processResponse(response.getResponseBodyAsStream, charset)
     } catch {
       case NonFatal(e) =>
         metrics.countRemoteException
-        throw new RemoteSolrException(httpStatus, e.getMessage(), e)
+        throw new RemoteSolrException(httpStatus, e.getMessage, e)
     }
 
     if (httpStatus != 200) {
@@ -714,7 +715,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   }
 
   @throws[RemoteSolrException]
-  protected def validateMimeType(expectedContentType: String, response: Response) {
+  protected def validateMimeType(expectedContentType: String, response: Response): Unit = {
     if (expectedContentType != null) {
       val expectedMimeType = getMimeType(expectedContentType).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
       val actualMimeType = getMimeType(response.getContentType).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
@@ -726,10 +727,9 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
           msg = msg + "\n" + IOUtils.toString(response.getResponseBodyAsStream, encoding)
         }
         catch {
-          case e: IOException => {
+          case e: IOException =>
             metrics.countRemoteException
             throw new RemoteSolrException(response.getStatusCode, s"$msg Unfortunately could not parse response (for debugging) with encoding $encoding", e)
-          }
         }
         metrics.countRemoteException
         throw new RemoteSolrException(response.getStatusCode, msg, null)
@@ -755,7 +755,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
     }
     if (reason == null) {
       val msg = new StringBuilder()
-      msg.append(response.getStatusText())
+      msg.append(response.getStatusText)
       msg.append("\n\n")
       msg.append("request: " + url)
       reason = msg.toString()
@@ -765,6 +765,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
 
 }
 
+//noinspection ConvertibleToMethodValue
 trait TypedAsyncSolrClient[F[_], ASC <: AsyncSolrClient[F]] {
 
   protected implicit def futureFactory: FutureFactory[F]

--- a/src/main/scala/io/ino/solrs/HttpUtils.scala
+++ b/src/main/scala/io/ino/solrs/HttpUtils.scala
@@ -1,7 +1,5 @@
 package io.ino.solrs
 
-import org.apache.http.HeaderElement
-
 /**
  * Created by magro on 4/29/14.
  */

--- a/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
@@ -24,7 +24,6 @@ import org.asynchttpclient.AsyncHttpClient
 import scala.collection.JavaConverters._
 import scala.compat.java8.FunctionConverters._
 import scala.compat.java8.OptionConverters._
-import scala.language.higherKinds
 
 /**
  * Java API: Async, non-blocking Solr Server that allows to make requests to Solr.

--- a/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
@@ -26,8 +26,8 @@ import scala.compat.java8.FunctionConverters._
 import scala.compat.java8.OptionConverters._
 
 /**
- * Java API: Async, non-blocking Solr Server that allows to make requests to Solr.
- * The usage shall be similar to the <a href="https://wiki.apache.org/solr/Solrj">solrj SolrServer</a>,
+ * Java API: Async, non-blocking Solr Client that allows to make requests to Solr.
+ * The usage shall be similar to the <a href="https://wiki.apache.org/solr/Solrj">solrj SolrClient</a>,
  * so request returns a [[java.util.concurrent.CompletionStage CompletionStage]] of a
  * [[org.apache.solr.client.solrj.SolrResponse SolrResponse]].
  *
@@ -61,7 +61,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Performs a request to a solr server taking the preferred server into account if provided.
     *
     * @param r         the request to send to the solr server.
-    * @param preferred the server that should be preferred to process the request. Specific [[io.ino.solrs.LoadBalancer LoadBalancer]]
+    * @param preferred the server that should be preferred to process the request. Specific [[_root_.io.ino.solrs.LoadBalancer LoadBalancer]]
     *                  implementations have to support this and might add their own semantics.
     * @return the response and the server that handled the request.
     */
@@ -72,7 +72,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Adds a collection of documents, specifying max time before they become committed
     *
     * @param docs the collection of documents
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(docs: util.Collection[SolrInputDocument]): CompletionStage[UpdateResponse] =
     super.addDocs(docs = docs.asScala)
@@ -82,7 +82,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param docs           the collection of documents
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(docs: util.Collection[SolrInputDocument], commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addDocs(docs = docs.asScala, commitWithinMs = commitWithinMs)
@@ -92,7 +92,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection the Solr collection to add documents to
     * @param docs       the collection of documents
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(collection: String, docs: util.Collection[SolrInputDocument]): CompletionStage[UpdateResponse] =
     super.addDocs(Option(collection), docs.asScala)
@@ -103,7 +103,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param collection     the Solr collection to add documents to
     * @param docs           the collection of documents
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(collection: String, docs: util.Collection[SolrInputDocument], commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addDocs(Option(collection), docs.asScala, commitWithinMs)
@@ -112,7 +112,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Adds the documents supplied by the given iterator.
     *
     * @param docIterator the iterator which returns SolrInputDocument instances
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(docIterator: util.Iterator[SolrInputDocument]): CompletionStage[UpdateResponse] =
     super.addDocs(docIterator.asScala)
@@ -122,7 +122,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection  the Solr collection to add documents to
     * @param docIterator the iterator which returns SolrInputDocument instances
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDocs(collection: String, docIterator: util.Iterator[SolrInputDocument]): CompletionStage[UpdateResponse] =
     super.addDocs(collection, docIterator.asScala)
@@ -131,7 +131,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Adds a single document specifying max time before it becomes committed
     *
     * @param doc the input document
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDoc(doc: SolrInputDocument): CompletionStage[UpdateResponse] = super.addDoc(doc = doc)
 
@@ -140,7 +140,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param doc            the input document
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDoc(doc: SolrInputDocument, commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addDoc(doc = doc, commitWithinMs = commitWithinMs)
@@ -150,7 +150,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection the Solr collection to add the document to
     * @param doc        the input document
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDoc(collection: String, doc: SolrInputDocument): CompletionStage[UpdateResponse] =
     super.addDoc(Option(collection), doc)
@@ -161,98 +161,98 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param collection     the Solr collection to add the document to
     * @param doc            the input document
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addDoc(collection: String, doc: SolrInputDocument, commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addDoc(Option(collection), doc, commitWithinMs)
 
   /**
     * Adds a single bean specifying max time before it becomes committed
-    * The bean is converted to a {@link SolrInputDocument} by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The bean is converted to a [[org.apache.solr.common.SolrInputDocument SolrInputDocument]] by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param obj the input bean
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBean(obj: Any): CompletionStage[UpdateResponse] = super.addBean(obj = obj)
 
   /**
     * Adds a single bean specifying max time before it becomes committed
-    * The bean is converted to a {@link SolrInputDocument} by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The bean is converted to a [[org.apache.solr.common.SolrInputDocument SolrInputDocument]] by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param obj the input bean
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBean(obj: Any, commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addBean(obj = obj, commitWithinMs = commitWithinMs)
 
   /**
     * Adds a single bean specifying max time before it becomes committed
-    * The bean is converted to a {@link SolrInputDocument} by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The bean is converted to a [[org.apache.solr.common.SolrInputDocument SolrInputDocument]] by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection to Solr collection to add documents to
     * @param obj        the input bean
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBean(collection: String, obj: Any): CompletionStage[UpdateResponse] = super.addBean(Option(collection), obj)
 
   /**
     * Adds a single bean specifying max time before it becomes committed
-    * The bean is converted to a {@link SolrInputDocument} by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The bean is converted to a [[org.apache.solr.common.SolrInputDocument SolrInputDocument]] by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection to Solr collection to add documents to
     * @param obj        the input bean
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBean(collection: String, obj: Any, commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addBean(Option(collection), obj, commitWithinMs)
 
   /**
     * Adds a collection of beans specifying max time before they become committed
-    * The beans are converted to {@link SolrInputDocument}s by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The beans are converted to [[org.apache.solr.common.SolrInputDocument SolrInputDocument]]s by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param beans the collection of beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(beans: util.Collection[_]): CompletionStage[UpdateResponse] = super.addBeans(beans = beans.asScala)
 
   /**
     * Adds a collection of beans specifying max time before they become committed
-    * The beans are converted to {@link SolrInputDocument}s by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The beans are converted to [[org.apache.solr.common.SolrInputDocument SolrInputDocument]]s by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param beans          the collection of beans
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(beans: util.Collection[_], commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addBeans(beans = beans.asScala, commitWithinMs = commitWithinMs)
 
   /**
     * Adds a collection of beans specifying max time before they become committed
-    * The beans are converted to {@link SolrInputDocument}s by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The beans are converted to [[org.apache.solr.common.SolrInputDocument SolrInputDocument]]s by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection the Solr collection to add documents to
     * @param beans      the collection of beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(collection: String, beans: util.Collection[_]): CompletionStage[UpdateResponse] =
     super.addBeans(Option(collection), beans.asScala)
 
   /**
     * Adds a collection of beans specifying max time before they become committed
-    * The beans are converted to {@link SolrInputDocument}s by the client's
-    * {@link org.apache.solr.client.solrj.beans.DocumentObjectBinder}
+    * The beans are converted to [[org.apache.solr.common.SolrInputDocument SolrInputDocument]]s by the client's
+    * [[org.apache.solr.client.solrj.beans.DocumentObjectBinder DocumentObjectBinder]]
     *
     * @param collection     the Solr collection to add documents to
     * @param beans          the collection of beans
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(collection: String, beans: util.Collection[_], commitWithinMs: Int): CompletionStage[UpdateResponse] =
     super.addBeans(Option(collection), beans.asScala, commitWithinMs)
@@ -261,7 +261,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Adds the beans supplied by the given iterator.
     *
     * @param beanIterator the iterator which returns Beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(beanIterator: util.Iterator[_]): CompletionStage[UpdateResponse] = super.addBeans(beanIterator.asScala)
 
@@ -270,7 +270,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection   the Solr collection to add the documents to
     * @param beanIterator the iterator which returns Beans
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} from the server
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] from the server
     */
   def addBeans(collection: String, beanIterator: util.Iterator[_]): CompletionStage[UpdateResponse] =
     super.addBeans(collection, beanIterator.asScala)
@@ -278,7 +278,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
   /**
     * Performs an explicit commit, causing pending documents to be committed for indexing
     *
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(): CompletionStage[UpdateResponse] = super.commit()
@@ -289,7 +289,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitFlush    block until index changes are flushed to disk
     * @param waitSearcher block until a new searcher is opened and registered as the
     *                     main query searcher, making the changes visible
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(waitFlush: Boolean, waitSearcher: Boolean): CompletionStage[UpdateResponse] =
@@ -303,7 +303,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *                     main query searcher, making the changes visible
     * @param softCommit   makes index changes visible while neither fsync-ing index files
     *                     nor writing a new index descriptor
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(waitFlush: Boolean, waitSearcher: Boolean, softCommit: Boolean): CompletionStage[UpdateResponse] =
@@ -313,7 +313,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Performs an explicit commit, causing pending documents to be committed for indexing
     *
     * @param collection the Solr collection to send the commit to
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(collection: String): CompletionStage[UpdateResponse] = super.commit(Option(collection))
@@ -325,7 +325,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitFlush    block until index changes are flushed to disk
     * @param waitSearcher block until a new searcher is opened and registered as the
     *                     main query searcher, making the changes visible
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(collection: String, waitFlush: Boolean, waitSearcher: Boolean): CompletionStage[UpdateResponse] =
@@ -340,7 +340,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *                     main query searcher, making the changes visible
     * @param softCommit   makes index changes visible while neither fsync-ing index files
     *                     nor writing a new index descriptor
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def commit(collection: String, waitFlush: Boolean, waitSearcher: Boolean, softCommit: Boolean): CompletionStage[UpdateResponse] =
@@ -350,7 +350,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Performs an explicit optimize, causing a merge of all segments to one.
     * Note: In most cases it is not required to do explicit optimize
     *
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(): CompletionStage[UpdateResponse] = super.optimize()
@@ -362,7 +362,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitFlush    block until index changes are flushed to disk
     * @param waitSearcher block until a new searcher is opened and registered as
     *                     the main query searcher, making the changes visible
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(waitFlush: Boolean, waitSearcher: Boolean): CompletionStage[UpdateResponse] =
@@ -376,7 +376,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitSearcher block until a new searcher is opened and registered as
     *                     the main query searcher, making the changes visible
     * @param maxSegments  optimizes down to at most this number of segments
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(waitFlush: Boolean, waitSearcher: Boolean, maxSegments: Int): CompletionStage[UpdateResponse] =
@@ -387,7 +387,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Note: In most cases it is not required to do explicit optimize
     *
     * @param collection the Solr collection to send the optimize to
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(collection: String): CompletionStage[UpdateResponse] = super.optimize(Option(collection))
@@ -400,7 +400,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitFlush    block until index changes are flushed to disk
     * @param waitSearcher block until a new searcher is opened and registered as
     *                     the main query searcher, making the changes visible
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(collection: String, waitFlush: Boolean, waitSearcher: Boolean): CompletionStage[UpdateResponse] =
@@ -415,7 +415,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param waitSearcher block until a new searcher is opened and registered as
     *                     the main query searcher, making the changes visible
     * @param maxSegments  optimizes down to at most this number of segments
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def optimize(collection: String, waitFlush: Boolean, waitSearcher: Boolean, maxSegments: Int): CompletionStage[UpdateResponse] =
@@ -427,7 +427,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * added may have been committed due to autoCommit, buffer full, other client performing
     * a commit etc.
     *
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def rollback(): CompletionStage[UpdateResponse] = super.rollback()
@@ -439,7 +439,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * a commit etc.
     *
     * @param collection the Solr collection to send the rollback to
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def rollback(collection: String): CompletionStage[UpdateResponse] = super.rollback(Option(collection))
@@ -448,7 +448,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Deletes a single document by unique ID, specifying max time before commit
     *
     * @param id the ID of the document to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteById(id: String): CompletionStage[UpdateResponse] = super.deleteById(id = id)
@@ -458,7 +458,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param id             the ID of the document to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteById(id: String, commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -469,7 +469,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection the Solr collection to delete the document from
     * @param id         the ID of the document to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteById(collection: String, id: String): CompletionStage[UpdateResponse] =
@@ -481,7 +481,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param collection the Solr collection to delete the document from
     * @param id         the ID of the document to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteById(collection: String, id: String, commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -491,7 +491,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Deletes a list of documents by unique ID, specifying max time before commit
     *
     * @param ids the list of document IDs to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByIds(ids: util.List[String]): CompletionStage[UpdateResponse] = super.deleteByIds(ids = ids.asScala)
@@ -501,7 +501,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param ids            the list of document IDs to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByIds(ids: util.List[String], commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -512,7 +512,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection the Solr collection to delete the documents from
     * @param ids        the list of document IDs to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByIds(collection: String, ids: util.List[String]): CompletionStage[UpdateResponse] =
@@ -524,7 +524,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param collection     the Solr collection to delete the documents from
     * @param ids            the list of document IDs to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByIds(collection: String, ids: util.List[String], commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -534,7 +534,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Deletes documents from the index based on a query, specifying max time before commit
     *
     * @param query the query expressing what documents to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByQuery(query: String): CompletionStage[UpdateResponse] = super.deleteByQuery(query = query)
@@ -544,7 +544,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param query          the query expressing what documents to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByQuery(query: String, commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -555,7 +555,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *
     * @param collection the Solr collection to delete the documents from
     * @param query      the query expressing what documents to delete
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByQuery(collection: String, query: String): CompletionStage[UpdateResponse] =
@@ -567,7 +567,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @param collection     the Solr collection to delete the documents from
     * @param query          the query expressing what documents to delete
     * @param commitWithinMs max time (in ms) before a commit will happen
-    * @return an { @link org.apache.solr.client.solrj.response.UpdateResponse} containing the response
+    * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
   def deleteByQuery(collection: String, query: String, commitWithinMs: Int): CompletionStage[UpdateResponse] =
@@ -756,7 +756,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * Performs a query to a solr server taking the preferred server into account if provided.
     *
     * @param q         the query to send to the solr server.
-    * @param preferred the server that should be preferred to process the query. Specific [[io.ino.solrs.LoadBalancer LoadBalancer]]
+    * @param preferred the server that should be preferred to process the query. Specific [[_root_.io.ino.solrs.LoadBalancer LoadBalancer]]
     *                  implementations have to support this and might add their own semantics.
     * @return the response and the server that handled the query.
     */
@@ -766,7 +766,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
 
 object JavaAsyncSolrClient extends TypedAsyncSolrClient[CompletionStage, JavaAsyncSolrClient] {
 
-  private implicit val ff = JavaFutureFactory
+  private implicit val ff: JavaFutureFactory.type = JavaFutureFactory
 
   override protected def futureFactory: FutureFactory[CompletionStage] = JavaFutureFactory
 

--- a/src/main/scala/io/ino/solrs/LoadBalancer.scala
+++ b/src/main/scala/io/ino/solrs/LoadBalancer.scala
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
-import scala.language.higherKinds
-import scala.language.postfixOps
 
 trait LoadBalancer extends RequestInterceptor {
 

--- a/src/main/scala/io/ino/solrs/LoadBalancer.scala
+++ b/src/main/scala/io/ino/solrs/LoadBalancer.scala
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 trait LoadBalancer extends RequestInterceptor {
@@ -51,7 +52,7 @@ trait LoadBalancer extends RequestInterceptor {
 class SingleServerLB(val server: SolrServer) extends LoadBalancer {
   def this(baseUrl: String) = this(SolrServer(baseUrl))
   private val someServer = Some(server)
-  override def solrServer(r: SolrRequest[_], preferred: Option[SolrServer] = None) = someServer
+  override def solrServer(r: SolrRequest[_], preferred: Option[SolrServer] = None): Some[SolrServer] = someServer
   override val solrServers: SolrServers = new StaticSolrServers(IndexedSeq(server))
 }
 
@@ -153,6 +154,7 @@ object RoundRobinLB {
  * @param clock the clock to get the current time from. The tests using the maxDelay are
  *              run using a scheduled executor, therefore this interval uses the system clock
  */
+//noinspection ScalaUnnecessaryParentheses
 class FastestServerLB[F[_]](override val solrServers: SolrServers,
                             val collectionAndTestQuery: SolrServer => (String, SolrQuery),
                             minDelay: Duration = 100 millis,
@@ -172,11 +174,11 @@ class FastestServerLB[F[_]](override val solrServers: SolrServers,
 
   private val scheduler = Executors.newSingleThreadScheduledExecutor()
 
-  protected[solrs] val statsByServer = TrieMap.empty[SolrServer, PerformanceStats]
-  protected[solrs] val serverTestTimestamp = TrieMap.empty[SolrServer, Millisecond].withDefaultValue(Millisecond(0))
+  protected[solrs] val statsByServer: TrieMap[SolrServer, PerformanceStats] = TrieMap.empty[SolrServer, PerformanceStats]
+  protected[solrs] val serverTestTimestamp: mutable.Map[SolrServer, Millisecond] = TrieMap.empty[SolrServer, Millisecond].withDefaultValue(Millisecond(0))
   // "fast" servers are faster than the average of all servers, they're tested more frequently than slow servers.
   // slow servers e.g. are running in a separate dc and are not expected to suddenly perform significantly better
-  protected var fastServersByCollection = Map.empty[String, Set[SolrServer]].withDefaultValue(Set.empty)
+  protected var fastServersByCollection: Map[String, Set[SolrServer]] = Map.empty[String, Set[SolrServer]].withDefaultValue(Set.empty)
   private val lastServerIdx = new AtomicInteger(-1)
 
   private def collection(server: SolrServer): String = collectionAndTestQuery(server)._1
@@ -202,11 +204,11 @@ class FastestServerLB[F[_]](override val solrServers: SolrServers,
     solrServers match {
       case observable: ServerStateChangeObservable => observable.register(new StateChangeObserver {
         override def onStateChange(event: StateChange): Unit = event match {
-          case Removed(server, collection) if server.isEnabled =>
+          case Removed(server, _) if server.isEnabled =>
             // clean up
             statsByServer.remove(server)
             serverTestTimestamp.remove(server)
-          case StateChanged(from, to, collection) if from.isEnabled && !to.isEnabled =>
+          case StateChanged(from, to, _) if from.isEnabled && !to.isEnabled =>
             statsByServer.remove(from)
             serverTestTimestamp.remove(from)
           case _ => // ignore
@@ -348,8 +350,7 @@ class FastestServerLB[F[_]](override val solrServers: SolrServers,
    * Determines the servers that are tested more frequently.
    */
   protected def updateFastServers(): Unit = {
-    if(statsByServer.isEmpty) Map.empty
-    else {
+    if(statsByServer.nonEmpty) {
       val serversByCollection = statsByServer.keys.toSet.groupBy(collection)
       serversByCollection.foreach { case (collection, servers) =>
         val durationByServer = statsByServer.filterKeys(servers.contains).mapValues(_.predictDuration(TestQueryClass))
@@ -394,6 +395,7 @@ object FastestServerLB {
   import java.util.function.BiFunction
   import java.util.function.LongFunction
   import java.util.function.{Function => JFunction}
+  //noinspection ScalaUnnecessaryParentheses
   case class Builder(solrServers: SolrServers,
                      collectionAndTestQuery: SolrServer => (String, SolrQuery),
                      minDelay: Duration = 100 millis,

--- a/src/main/scala/io/ino/solrs/Metrics.scala
+++ b/src/main/scala/io/ino/solrs/Metrics.scala
@@ -1,5 +1,6 @@
 package io.ino.solrs
 
+//noinspection UnitMethodIsParameterless
 trait Metrics {
 
   def requestTime(timeInMillis: Long): Unit
@@ -17,9 +18,9 @@ trait Metrics {
 }
 
 object NoopMetrics extends Metrics {
-  override def requestTime(timeInMillis: Long) = {}
-  override def countException = {}
-  override def countRemoteException = {}
+  override def requestTime(timeInMillis: Long): Unit = {}
+  override def countException: Unit = {}
+  override def countRemoteException: Unit = {}
 }
 
 import com.codahale.metrics.MetricRegistry
@@ -34,10 +35,10 @@ class CodaHaleMetrics[F[_]](val registry: MetricRegistry = new MetricRegistry())
   private val transformResponseExceptionCounter = registry.meter(name(classOf[AsyncSolrClient[F]], "transform-response-exceptions"))
   private val exceptionCounter = registry.meter(name(classOf[AsyncSolrClient[F]], "other-exceptions"))
 
-  override def requestTime(timeInMillis: Long) = requestTimer.update(timeInMillis, MILLISECONDS)
+  override def requestTime(timeInMillis: Long): Unit = requestTimer.update(timeInMillis, MILLISECONDS)
 
-  override def countRemoteException = remoteSolrExceptionCounter.mark()
+  override def countRemoteException: Unit = remoteSolrExceptionCounter.mark()
 
-  override def countException = exceptionCounter.mark()
+  override def countException: Unit = exceptionCounter.mark()
 
 }

--- a/src/main/scala/io/ino/solrs/Metrics.scala
+++ b/src/main/scala/io/ino/solrs/Metrics.scala
@@ -25,7 +25,6 @@ object NoopMetrics extends Metrics {
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.MetricRegistry._
 import java.util.concurrent.TimeUnit._
-import scala.language.higherKinds
 
 class CodaHaleMetrics[F[_]](val registry: MetricRegistry = new MetricRegistry()) extends Metrics {
 

--- a/src/main/scala/io/ino/solrs/PerformanceStats.scala
+++ b/src/main/scala/io/ino/solrs/PerformanceStats.scala
@@ -51,7 +51,7 @@ class PerformanceStats(solrServer: SolrServer, initialPredictedResponseTime: Lon
 
   def requestStarted(queryClass: QueryClass): RequestHandle = {
     new RequestHandle {
-      override val startedAtMillis = clock.millis()
+      override val startedAtMillis: Duration = clock.millis()
       // store this request, so that it can be used for prediction
       currentRequestsFor(queryClass).add(this)
       override def finished(): Unit = {
@@ -229,7 +229,7 @@ object PerformanceStats {
     }
     
     def averageCountsAndDurations: Map[QueryClass, CountAndDuration] = {
-      requestCounts.map { case ((queryClass, count)) =>
+      requestCounts.map { case (queryClass, count) =>
         (queryClass, count -> requestDurationsInMillis(queryClass) / count)
       }.toMap
     }
@@ -252,11 +252,11 @@ object PerformanceStats {
 
     private val serverStats = new CountsAndDurations
 
-    val register = serverStats.record _
+    val register: (QueryClass, Duration) => Unit = serverStats.record
     
-    def averageDurations = serverStats.averageCountsAndDurations
+    def averageDurations: Map[QueryClass, (Count, Duration)] = serverStats.averageCountsAndDurations
 
-    def averageDuration = serverStats.averageDuration _
+    def averageDuration: QueryClass => Option[Duration] = serverStats.averageDuration
 
   }
 
@@ -275,7 +275,7 @@ object PerformanceStats {
    */
   class EvictingArray[T: ClassTag] private(_values: Array[T]) {
 
-    private val size = _values.size
+    private val size = _values.length
     private var length = 0
     private var pos = 0
 

--- a/src/main/scala/io/ino/solrs/RequestContext.scala
+++ b/src/main/scala/io/ino/solrs/RequestContext.scala
@@ -3,7 +3,6 @@ package io.ino.solrs
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.SolrResponse
 
-import scala.language.existentials
 import scala.concurrent.duration.Duration
 
 /**

--- a/src/main/scala/io/ino/solrs/RequestContext.scala
+++ b/src/main/scala/io/ino/solrs/RequestContext.scala
@@ -16,7 +16,7 @@ case class RequestContext[T <: SolrResponse](r: SolrRequest[_ <: T], preferred: 
   def failedRequest(server: SolrServer, duration: Duration, e: Throwable): RequestContext[T] =
     copy(failedRequests = failedRequests :+ RequestInfo(server, duration, e))
 
-  def triedServers = failedRequests.map(_.server)
+  def triedServers: Seq[SolrServer] = failedRequests.map(_.server)
 
   def hasTriedServer(server: SolrServer): Boolean = failedRequests.exists(_.server == server)
 

--- a/src/main/scala/io/ino/solrs/RetryPolicy.scala
+++ b/src/main/scala/io/ino/solrs/RetryPolicy.scala
@@ -93,7 +93,7 @@ object RetryPolicy {
   /**
    * Retries the given number of times.
    */
-  def AtMost(times: Int) = new RetryPolicy {
+  def AtMost(times: Int): RetryPolicy = new RetryPolicy {
     override def shouldRetry(e: Throwable, server: SolrServer, requestContext: RequestContext[_], lb: LoadBalancer): RetryDecision = {
       if(requestContext.triedServers.length < times) RetryDecision.Retry
       else RetryDecision.Fail

--- a/src/main/scala/io/ino/solrs/ServerStateObserver.scala
+++ b/src/main/scala/io/ino/solrs/ServerStateObserver.scala
@@ -7,7 +7,6 @@ import io.ino.solrs.future.{Future, FutureFactory, ScalaFutureFactory}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
-import scala.language.{higherKinds, postfixOps}
 import scala.util.Success
 import scala.xml.XML
 

--- a/src/main/scala/io/ino/solrs/ServerStateObserver.scala
+++ b/src/main/scala/io/ino/solrs/ServerStateObserver.scala
@@ -44,7 +44,7 @@ class PingStatusObserver[F[_]](solrServers: SolrServers, httpClient: AsyncHttpCl
   def this(solrServers: Seq[SolrServer], httpClient: AsyncHttpClient)
           (implicit futureFactory: FutureFactory[F] = ScalaFutureFactory) = this(new StaticSolrServers(solrServers.toIndexedSeq), httpClient)
 
-  private val logger = LoggerFactory.getLogger(getClass())
+  private val logger = LoggerFactory.getLogger(getClass)
 
   override def checkServerStatus(): Future[Unit] = {
     val futures = solrServers.all.map { server =>

--- a/src/main/scala/io/ino/solrs/SolrServer.scala
+++ b/src/main/scala/io/ino/solrs/SolrServer.scala
@@ -14,7 +14,7 @@ class SolrServer(val baseUrl: String) {
   @volatile
   var status: ServerStatus = Enabled
 
-  def isEnabled = status == Enabled
+  def isEnabled: Boolean = status == Enabled
 
   override def toString: String = s"SolrServer($baseUrl, $status)"
 

--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -257,7 +257,7 @@ class CloudSolrServers[F[_]](zkHost: String,
     serverChangeStateObservers += listener
   }
 
-  private def notifyObservers(oldState: Map[String, Seq[SolrServer]], newState: Map[String, Seq[SolrServer]]) = {
+  private def notifyObservers(oldState: Map[String, Seq[SolrServer]], newState: Map[String, Seq[SolrServer]]): Unit = {
     CloudSolrServers.diff(oldState, newState).foreach { event =>
       serverChangeStateObservers.foreach(_.onStateChange(event))
     }
@@ -348,10 +348,10 @@ object CloudSolrServers {
       val newServers = newState.getOrElse(collection, Nil)
       val changesFromOldState = changes(oldServers, newServers,
         stateChanged = (oldServer, newServer) => StateChanged(oldServer, newServer, collection),
-        onlyInServers2 = (server2) => Added(server2, collection))
+        onlyInServers2 = server2 => Added(server2, collection))
       val changesFromNewState = changes(newServers, oldServers,
         stateChanged = (newServer, oldServer) => StateChanged(oldServer, newServer, collection),
-        onlyInServers2 = (server2) => Removed(server2, collection))
+        onlyInServers2 = server2 => Removed(server2, collection))
       changesFromOldState ++ changesFromNewState
     }
 
@@ -367,7 +367,8 @@ object CloudSolrServers {
 
 }
 
-class ReloadingSolrServers[F[_]](url: String, extractor: Array[Byte] => IndexedSeq[SolrServer], httpClient: AsyncHttpClient)(implicit futureFactory: FutureFactory[F] = ScalaFutureFactory) extends SolrServers {
+class ReloadingSolrServers[F[_]](url: String, extractor: Array[Byte] => IndexedSeq[SolrServer], httpClient: AsyncHttpClient)
+                                (implicit futureFactory: FutureFactory[F] = ScalaFutureFactory) extends SolrServers {
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -23,9 +23,6 @@ import org.asynchttpclient.Response
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
-import scala.language.postfixOps
-import scala.language.higherKinds
-import scala.language.postfixOps
 import scala.util.control.NonFatal
 import scala.util.Failure
 import scala.util.Success
@@ -60,7 +57,6 @@ object StaticSolrServers {
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
-import scala.languageFeature.postfixOps
 
 private object ZkClusterStateUpdateTF {
   private val tg = new ThreadGroup("solrs-CloudSolrServersUpdate")

--- a/src/main/scala/io/ino/solrs/future/Future.scala
+++ b/src/main/scala/io/ino/solrs/future/Future.scala
@@ -1,7 +1,6 @@
 package io.ino.solrs.future
 
 import scala.collection.generic.CanBuildFrom
-import scala.language.higherKinds
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/io/ino/solrs/future/Future.scala
+++ b/src/main/scala/io/ino/solrs/future/Future.scala
@@ -101,7 +101,7 @@ trait FutureFactory[RFT[_]] {
 
   def newPromise[T]: Promise[T]
 
-  def toBase[T]: (Future[T] => RFT[T])
+  def toBase[T]: Future[T] => RFT[T]
 
 }
 

--- a/src/main/scala/io/ino/solrs/future/JavaFutureFactory.scala
+++ b/src/main/scala/io/ino/solrs/future/JavaFutureFactory.scala
@@ -10,14 +10,14 @@ import scala.util.Try
 class JavaFutureFactory extends FutureFactory[CompletionStage] {
   import scala.util.{Failure, Success}
 
-  def toBase[T]: (Future[T]) => CompletionStage[T] = {
+  def toBase[T]: Future[T] => CompletionStage[T] = {
     case sf: JavaFuture[T] => sf.inner
     case _ => throw new Exception("Wrong future type")
   }
 
   class JavaFuture[T](private[JavaFutureFactory] val inner: CompletionStage[T]) extends FutureBase[T] {
 
-    override def onComplete[U](func: (Try[T]) => U): Unit = {
+    override def onComplete[U](func: Try[T] => U): Unit = {
       inner.whenComplete(new BiConsumer[T, Throwable] {
         override def accept(value: T, ex: Throwable): Unit = {
           val trie = if(value != null) Success(value) else Failure(ex)

--- a/src/main/scala/io/ino/solrs/future/ScalaFutureFactory.scala
+++ b/src/main/scala/io/ino/solrs/future/ScalaFutureFactory.scala
@@ -10,19 +10,19 @@ object ScalaFutureFactory extends FutureFactory[SFuture] {
   import scala.util.{Failure, Success}
 
   // Implicit val to provide s.th. to import.
-  implicit val Implicit = ScalaFutureFactory
+  implicit val Implicit: ScalaFutureFactory.type = ScalaFutureFactory
 
-  def toBase[T]: (Future[T]) => SFuture[T] = {
+  def toBase[T]: Future[T] => SFuture[T] = {
     case sf: ScalaFuture[T] => sf.inner
     case _ => throw new Exception("Wrong future type")
   }
 
   class ScalaFuture[+T](f: SFuture[T]) extends FutureBase[T] {
-    val inner = f
+    val inner: SFuture[T] = f
 
     import Execution.Implicits.sameThreadContext
 
-    override def onComplete[U](func: (Try[T]) => U): Unit = inner.onComplete(func)
+    override def onComplete[U](func: Try[T] => U): Unit = inner.onComplete(func)
 
     def map[S](f: T => S): Future[S] = {
       val p = new ScalaPromise[S]
@@ -78,7 +78,7 @@ object ScalaFutureFactory extends FutureFactory[SFuture] {
   }
 
   class ScalaPromise[T] extends Promise[T] {
-    val inner = SPromise[T]()
+    val inner: SPromise[T] = SPromise[T]()
     def future: Future[T] = new ScalaFuture(inner.future)
     def success(value: T): Unit = inner.success(value)
     def failure(exception: Throwable): Unit = inner.failure(exception)

--- a/src/main/scala/io/ino/time/Units.scala
+++ b/src/main/scala/io/ino/time/Units.scala
@@ -1,6 +1,5 @@
 package io.ino.time
 
-import scala.language.implicitConversions
 import scala.math.Ordering
 
 object Units {

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
@@ -12,7 +12,6 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.control.NonFatal
 
 /**

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -11,7 +11,6 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.annotation.meta.field
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -22,7 +22,6 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientMocks.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientMocks.scala
@@ -9,7 +9,6 @@ import org.mockito.Mockito._
 
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.language.{higherKinds, postfixOps}
 import scala.util.{Success, Try}
 
 object AsyncSolrClientMocks {

--- a/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
@@ -17,7 +17,6 @@ import org.scalatest.time.{Millis, Span}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 /**
  * Test that starts ZK, solrRunners and our Class Under Test before all tests.

--- a/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
@@ -5,7 +5,6 @@ import java.nio.file.{Files, Paths}
 import org.apache.solr.common.cloud.ClusterState
 import org.scalatest._
 
-import scala.language.postfixOps
 
 /**
  * Test that starts ZK, solrRunners and our Class Under Test before all tests.

--- a/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
@@ -8,7 +8,6 @@ import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 /**
  * Test that starts uninitialized, there is no ZK and no solr servers started before tests. 

--- a/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
@@ -15,7 +15,6 @@ import org.scalatest.concurrent.Eventually._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class FastestServerLBSpec extends StandardFunSpec {
 

--- a/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
@@ -14,7 +14,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSpec, Matchers}
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class PingStatusObserverIntegrationSpec extends FunSpec with BeforeAndAfterAll with Eventually with IntegrationPatience with BeforeAndAfterEach with Matchers with FutureAwaits with MockitoSugar {
 

--- a/src/test/scala/io/ino/solrs/RetryPolicySpec.scala
+++ b/src/test/scala/io/ino/solrs/RetryPolicySpec.scala
@@ -8,7 +8,6 @@ import org.apache.solr.client.solrj.request.QueryRequest
 import org.scalatest.{FunSpec, Inside, Matchers}
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class RetryPolicySpec extends FunSpec with Matchers with Inside {
 

--- a/src/test/scala/io/ino/solrs/SolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/SolrServersSpec.scala
@@ -6,7 +6,6 @@ import org.scalatest.{FunSpec, Matchers}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class SolrServersSpec extends FunSpec with Matchers with FutureAwaits {
 

--- a/src/test/scala/io/ino/solrs/future/FutureFactorySpec.scala
+++ b/src/test/scala/io/ino/solrs/future/FutureFactorySpec.scala
@@ -9,7 +9,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 import scala.concurrent.{Future => SFuture}
-import scala.language.{higherKinds, postfixOps}
 
 class ScalaFutureFactorySpec extends FutureFactorySpec[SFuture] with FutureAwaits {
   import scala.concurrent.duration._


### PR DESCRIPTION
* Replace individual language feature imports by scalacOptions in sbt
* Get rid of various warnings (missing return type etc)