### PR TITLE
Shard support:  Optimize request routing if _route_ param is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,6 @@ be passed to `RoundRobinLB`/`FastestServerLB`).
 Solr Cloud is supported with the following properties / restrictions:
 
 * No Collection Aliases supported (a PR's welcome)
-* No optimized [document/request routing](https://lucene.apache.org/solr/guide/7_4/shards-and-indexing-data-in-solrcloud.html#document-routing) for shards via the `_route_` parameter, to direct queries to specific shards (please raise an issue or submit a pull request)
 * Can use a default collection, if this is not provided, per request the `SolrQuery` must specify
   the collection via the "collection" parameter.
 * New solr servers or solr servers that changed their state from inactive (e.g. down) to active can be tested

--- a/src/main/scala/io/ino/solrs/SolrServer.scala
+++ b/src/main/scala/io/ino/solrs/SolrServer.scala
@@ -27,10 +27,11 @@ class SolrServer(val baseUrl: String) {
 }
 
 object SolrServer {
-  def apply(baseUrl: String): SolrServer = {
-    val fixedUrl = if(baseUrl.endsWith("/")) baseUrl.dropRight(1) else baseUrl
-    new SolrServer(fixedUrl)
-  }
+
+  def apply(baseUrl: String): SolrServer = new SolrServer(fixUrl(baseUrl))
+
+  private[solrs] def fixUrl(baseUrl: String): String = if (baseUrl.endsWith("/")) baseUrl.dropRight(1) else baseUrl
+
   def apply(baseUrl: String, status: ServerStatus): SolrServer = {
     val res = SolrServer(baseUrl)
     res.status = status

--- a/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
@@ -7,13 +7,22 @@ import io.ino.time.Clock
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.embedded.JettySolrRunner
 import org.apache.solr.client.solrj.impl.CloudSolrClient
+import org.apache.solr.client.solrj.impl.HttpSolrClient
+import org.apache.solr.client.solrj.request.QueryRequest
 import org.apache.solr.client.solrj.response.QueryResponse
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.apache.solr.common.SolrInputDocument
+import org.apache.solr.common.params.ShardParams.SHARDS
+import org.apache.solr.common.params.ShardParams._ROUTE_
+import org.mockito.Matchers.{eq => mockEq}
+import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.scalatest.concurrent.Eventually.{eventually, _}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.time.{Millis, Span}
+import org.scalatest.time.Millis
+import org.scalatest.time.Span
 
+import scala.collection.breakOut
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -54,13 +63,22 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
     eventually(Timeout(10 seconds)) {
       solrJClient.deleteByQuery("*:*")
     }
-    import scala.collection.JavaConverters._
+    import scala.collection.JavaConverters.seqAsJavaListConverter
     solrJClient.add(someDocs.asJava)
     solrJClient.commit()
   }
 
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    // ensure that all nodes are running, and none's left in stopped state
+    solrRunner.jettySolrRunners.foreach { jetty =>
+      if(jetty.isStopped) SolrRunner.startJetty(jetty)
+    }
+  }
+
   override def afterEach(): Unit = {
     cut.shutdown()
+    super.afterEach()
   }
 
   override def afterAll() {
@@ -113,6 +131,57 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
       }
     }
 
+    it("should route requests according to _route_ param") {
+      cut = new CloudSolrServers(zkConnectString, defaultCollection = Some("collection1"), clusterStateUpdateInterval = 100 millis)
+      cut.setAsyncSolrClient(mockDoRequest(mock[AsyncSolrClient])(Clock.mutable))
+
+      val docs = indexShardedDocs(shardKey = docNr => s"KEY$docNr")
+
+      // for each document determine in which shard replica (core) it's stored, because this reflects the decision
+      // of Solrs internal routing logic.
+      // we only want to query these replicas, i.e. route the request to them
+
+      def serverContainsDoc(url: String, id: String): Boolean = {
+        val client = new HttpSolrClient.Builder(url).withHttpClient(solrJClient.getHttpClient).build()
+        // restrict search to exactly this shard replica
+        client.query(new SolrQuery(s"""id:"$id"""").setParam(SHARDS, url)).getResults.getNumFound > 0
+      }
+
+      val expectedServersByDoc: Map[SolrInputDocument, List[String]] = docs.map { doc =>
+        val id = doc.getFieldValue("id").toString
+        val expectedServers = solrServerUrls.filter(serverContainsDoc(_, id))
+        doc -> expectedServers
+      }(breakOut)
+
+      expectedServersByDoc.foreach { case (doc, expectedServers) =>
+        val id = doc.getFieldValue("id").toString
+        val route = id.substring(0, id.indexOf('!') + 1)
+        val request = new QueryRequest(new SolrQuery("*:*").setParam(_ROUTE_, route))
+        cut.matching(request) should contain theSameElementsAs expectedServers.map(SolrServer(_, Enabled))
+      }
+
+      // now stop a server
+      val solrServers = solrServerUrls.map(SolrServer(_, Enabled))
+      SolrRunner.stopJetty(solrRunner.jettySolrRunners.head)
+        solrServers.head.status = Failed
+        eventually {
+          cut.all should contain theSameElementsAs solrServers
+        }
+
+        // ensure that the returned servers per route also contain the expected status
+        expectedServersByDoc.foreach { case (doc, expectedServers) =>
+          val id = doc.getFieldValue("id").toString
+          val route = id.substring(0, id.indexOf('!') + 1)
+          val request = new QueryRequest(new SolrQuery("*:*").setParam(_ROUTE_, route))
+          val expectedServersWithStatus = expectedServers.map {
+            case serverUrl if serverUrl == solrServers.head.baseUrl => SolrServer(serverUrl, Failed)
+            case serverUrl => SolrServer(serverUrl, Enabled)
+          }
+          cut.matching(request) should contain theSameElementsAs expectedServersWithStatus
+        }
+
+    }
+
     it("should test solr instances according to the WarmupQueries") {
       val queries = Seq(new SolrQuery("foo"))
       val warmupQueries = WarmupQueries(queriesByCollection = _ => queries, count = 2)
@@ -159,4 +228,24 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
 
   }
 
+  private def indexShardedDocs(shardKey: Int => String): List[SolrInputDocument] = {
+
+    eventually(Timeout(10 seconds)) {
+      solrJClient.deleteByQuery("*:*")
+    }
+
+    val docs = (1 to 10).map { i =>
+      newInputDoc(s"${shardKey(i)}!id$i", s"doc$i", s"cat$i", i)
+    }.toList
+    import scala.collection.JavaConverters.seqAsJavaListConverter
+    solrJClient.add(docs.asJava)
+    solrJClient.commit()
+
+    eventually {
+      val response = asyncSolrClients.values.head.query(new SolrQuery("*:*").setRows(10)).map(getIds)
+      await(response) should contain theSameElementsAs docs.map(_.getFieldValue("id").toString)
+    }
+
+    docs
+  }
 }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
@@ -28,7 +28,7 @@ class CloudSolrServersSpec extends FunSpec with Matchers {
         )
       )
 
-      implicit val solrServerOrd = Ordering[String].on[SolrServer](s => s.baseUrl)
+      implicit val solrServerOrd: Ordering[SolrServer] = Ordering[String].on[SolrServer](s => s.baseUrl)
 
       events should contain theSameElementsAs Seq(
         Removed(SolrServer("h10", Enabled), "col1"),

--- a/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
@@ -46,8 +46,8 @@ class CloudSolrServersSpec extends FunSpec with Matchers {
       val bytes = Files.readAllBytes(Paths.get(this.getClass.getResource("/cluster_status.json").toURI))
       val cs = ClusterState.load(1, bytes, Set("server1:8983_solr").asJava)
 
-      val collectionToServers = CloudSolrServers.getCollectionToServers(cs)
-      collectionToServers("my-collection").map(_.baseUrl) should contain allOf(
+      val collectionToServers = CloudSolrServers.getCollections(cs)
+      collectionToServers("my-collection").servers.map(_.baseUrl) should contain allOf(
         "http://server1:8983/solr/my-collection_shard1_replica1",
         "http://server2:8983/solr/my-collection_shard1_replica2",
         "http://server3:8983/solr/my-collection_shard2_replica1",


### PR DESCRIPTION
* Update CloudSolrServersIntegrationSpec to test with multiple shards
* Optimize request routing if `_route_` param is given

Closes #41 