### PR TITLE
Optimize routing: Send updates to shard leader

### DIFF
--- a/src/main/scala/io/ino/solrs/PerformanceStats.scala
+++ b/src/main/scala/io/ino/solrs/PerformanceStats.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 /**
  * Statistics for a solr server.
  */
-class PerformanceStats(solrServer: SolrServer, initialPredictedResponseTime: Long, clock: Clock) {
+class PerformanceStats(val solrServer: SolrServer, initialPredictedResponseTime: Long, clock: Clock) {
 
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/src/main/scala/io/ino/solrs/SolrServer.scala
+++ b/src/main/scala/io/ino/solrs/SolrServer.scala
@@ -1,39 +1,47 @@
 package io.ino.solrs
 
+final case class SolrServerId(url: String) extends AnyVal
+
 /**
  * Represents a solr host.
  *
  * @param baseUrl the solr server's base url, must not end with a slash.
  */
-class SolrServer(val baseUrl: String) {
+class SolrServer(val baseUrl: String, val isLeader: Boolean) {
 
   require(!baseUrl.endsWith("/"), s"baseUrl must not end with '/', but was '$baseUrl'.")
 
   // Not a case class, because then status would not be included in toString/equals/hashCode
 
+  val id: SolrServerId = SolrServerId(baseUrl)
+
   @volatile
   var status: ServerStatus = Enabled
 
+  def withLeader(isLeader: Boolean): SolrServer =
+    if(isLeader == this.isLeader) this
+    else SolrServer(baseUrl, status, isLeader)
+
   def isEnabled: Boolean = status == Enabled
 
-  override def toString: String = s"SolrServer($baseUrl, $status)"
+  override def toString: String = s"SolrServer($baseUrl, $status, $isLeader)"
 
   override def equals(other: Any): Boolean = other match {
-    case that: SolrServer => status == that.status && baseUrl == that.baseUrl
+    case that: SolrServer => isLeader == that.isLeader && status == that.status && baseUrl == that.baseUrl
     case _ => false
   }
 
-  override def hashCode(): Int = status.hashCode() + baseUrl.hashCode
+  override def hashCode(): Int = isLeader.hashCode() + status.hashCode() + baseUrl.hashCode
 }
 
 object SolrServer {
 
-  def apply(baseUrl: String): SolrServer = new SolrServer(fixUrl(baseUrl))
+  def apply(baseUrl: String, isLeader: Boolean = false): SolrServer = new SolrServer(fixUrl(baseUrl), isLeader)
 
   private[solrs] def fixUrl(baseUrl: String): String = if (baseUrl.endsWith("/")) baseUrl.dropRight(1) else baseUrl
 
-  def apply(baseUrl: String, status: ServerStatus): SolrServer = {
-    val res = SolrServer(baseUrl)
+  def apply(baseUrl: String, status: ServerStatus, isLeader: Boolean): SolrServer = {
+    val res = SolrServer(baseUrl, isLeader)
     res.status = status
     res
   }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
@@ -3,6 +3,7 @@ package io.ino.solrs
 import io.ino.solrs.AsyncSolrClientMocks.mockDoRequest
 import io.ino.solrs.CloudSolrServers.WarmupQueries
 import io.ino.solrs.SolrMatchers.hasQuery
+import io.ino.solrs.SolrMatchers.hasBaseUrlOf
 import io.ino.time.Clock
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.embedded.JettySolrRunner
@@ -13,7 +14,6 @@ import org.apache.solr.client.solrj.response.QueryResponse
 import org.apache.solr.common.SolrInputDocument
 import org.apache.solr.common.params.ShardParams.SHARDS
 import org.apache.solr.common.params.ShardParams._ROUTE_
-import org.mockito.Matchers.{eq => mockEq}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually.eventually
@@ -42,6 +42,7 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
 
   private def zkConnectString = solrRunner.zkAddress
   private def solrServerUrls = solrRunner.solrCoreUrls
+  private def solrServerUrlsEnabled = solrServerUrls.map(SolrServer(_, Enabled, isLeader = false))
 
   private var solrJClient: CloudSolrClient = _
   private var asyncSolrClients: Map[JettySolrRunner, AsyncSolrClient] = _
@@ -96,7 +97,7 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
       cut.setAsyncSolrClient(mockDoRequest(mock[AsyncSolrClient])(Clock.mutable))
 
       eventually {
-        cut.all should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled))
+        cut.all.map(_.withLeader(false)) should contain theSameElementsAs solrServerUrlsEnabled
       }
 
       asyncSolrClients.foreach { case(_, client) =>
@@ -113,21 +114,21 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
       cut = new CloudSolrServers(zkConnectString, clusterStateUpdateInterval = 100 millis)
       cut.setAsyncSolrClient(mockDoRequest(mock[AsyncSolrClient])(Clock.mutable))
 
-      val expectedSolrServers = solrServerUrls.map(SolrServer(_, Enabled))
+      val expectedSolrServers = solrServerUrlsEnabled
       eventually {
-        cut.all should contain theSameElementsAs expectedSolrServers
+        cut.all.map(_.withLeader(false)) should contain theSameElementsAs expectedSolrServers
       }
 
       SolrRunner.stopJetty(solrRunner.jettySolrRunners.head)
       expectedSolrServers.head.status = Failed
       eventually {
-        cut.all should contain theSameElementsAs expectedSolrServers
+        cut.all.map(_.withLeader(false)) should contain theSameElementsAs expectedSolrServers
       }
 
       SolrRunner.startJetty(solrRunner.jettySolrRunners.head)
       expectedSolrServers.head.status = Enabled
       eventually {
-        cut.all should contain theSameElementsAs expectedSolrServers
+        cut.all.map(_.withLeader(false)) should contain theSameElementsAs expectedSolrServers
       }
     }
 
@@ -157,15 +158,15 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
         val id = doc.getFieldValue("id").toString
         val route = id.substring(0, id.indexOf('!') + 1)
         val request = new QueryRequest(new SolrQuery("*:*").setParam(_ROUTE_, route))
-        cut.matching(request) should contain theSameElementsAs expectedServers.map(SolrServer(_, Enabled))
+        cut.matching(request).map(_.withLeader(false)) should contain theSameElementsAs expectedServers.map(SolrServer(_, Enabled, isLeader = false))
       }
 
       // now stop a server
-      val solrServers = solrServerUrls.map(SolrServer(_, Enabled))
+      val solrServers = solrServerUrlsEnabled
       SolrRunner.stopJetty(solrRunner.jettySolrRunners.head)
         solrServers.head.status = Failed
         eventually {
-          cut.all should contain theSameElementsAs solrServers
+          cut.all.map(_.withLeader(false)) should contain theSameElementsAs solrServers
         }
 
         // ensure that the returned servers per route also contain the expected status
@@ -174,10 +175,10 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
           val route = id.substring(0, id.indexOf('!') + 1)
           val request = new QueryRequest(new SolrQuery("*:*").setParam(_ROUTE_, route))
           val expectedServersWithStatus = expectedServers.map {
-            case serverUrl if serverUrl == solrServers.head.baseUrl => SolrServer(serverUrl, Failed)
-            case serverUrl => SolrServer(serverUrl, Enabled)
+            case serverUrl if serverUrl == solrServers.head.baseUrl => SolrServer(serverUrl, Failed, isLeader = false)
+            case serverUrl => SolrServer(serverUrl, Enabled, isLeader = false)
           }
-          cut.matching(request) should contain theSameElementsAs expectedServersWithStatus
+          cut.matching(request).map(_.withLeader(false)) should contain theSameElementsAs expectedServersWithStatus
         }
 
     }
@@ -199,13 +200,13 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
       // as soon as the response is set the LB should provide the servers...
       standardResponsePromise.success(new QueryResponse())
       eventually {
-        cut.all should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled))
+        cut.all.map(_.withLeader(false)) should contain theSameElementsAs solrServerUrlsEnabled
       }
 
       // and the servers should have been tested with queries
-      solrServerUrls.map(SolrServer(_, Enabled)).foreach { solrServer =>
+      solrServerUrlsEnabled.foreach { solrServer =>
         warmupQueries.queriesByCollection("col1").foreach { q =>
-          verify(asyncSolrClient, times(warmupQueries.count)).doExecute[QueryResponse](mockEq(solrServer), hasQuery(q))(any())
+          verify(asyncSolrClient, times(warmupQueries.count)).doExecute[QueryResponse](hasBaseUrlOf(solrServer), hasQuery(q))(any())
         }
       }
     }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
@@ -69,7 +69,7 @@ class CloudSolrServersUninitializedIntegrationSpec extends StandardFunSpec {
       solrRunner = SolrCloudRunner.start(2, List(SolrCollection("collection1", 2, 1)), Some("collection1"), Some(zkPort))
 
       eventually(Timeout(20 seconds)) {
-        cut.get.all should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled))
+        cut.get.all.map(_.withLeader(false)) should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled, isLeader = false))
       }
 
     }

--- a/src/test/scala/io/ino/solrs/SolrMatchers.scala
+++ b/src/test/scala/io/ino/solrs/SolrMatchers.scala
@@ -4,8 +4,18 @@ import org.apache.solr.client.solrj.request.QueryRequest
 import org.apache.solr.common.params.SolrParams
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Matchers.hasProperty
+import org.mockito.ArgumentMatcher
 import org.mockito.Matchers.argThat
 
 object SolrMatchers {
+
   def hasQuery(query: SolrParams): QueryRequest = argThat(hasProperty("params", equalTo(query)))
+
+  def hasBaseUrlOf(solrServer: SolrServer): SolrServer = argThat(new ArgumentMatcher[SolrServer] {
+    override def matches(argument: scala.Any): Boolean = argument match {
+      case server: SolrServer => server.baseUrl == solrServer.baseUrl
+      case _ => false
+    }
+  })
+
 }

--- a/src/test/scala/io/ino/solrs/StandardFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/StandardFunSpec.scala
@@ -1,14 +1,20 @@
 package io.ino.solrs
 
 import io.ino.solrs.future.ScalaFutureFactory
-import org.scalatest.{Matchers, BeforeAndAfterEach, BeforeAndAfterAll, FunSpec}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSpec, Matchers}
 
 import scala.concurrent.Future
 
 /**
  * Default FunSpec mixing in various standard traits, and also ScalaFutureFactory.
  */
-abstract class StandardFunSpec extends FunSpec with BeforeAndAfterAll with BeforeAndAfterEach with Matchers with FutureAwaits with NewMockitoSugar {
+//noinspection TypeAnnotation
+abstract class StandardFunSpec extends FunSpec
+  with BeforeAndAfterAll
+  with BeforeAndAfterEach
+  with Matchers
+  with FutureAwaits
+  with NewMockitoSugar {
 
   protected implicit val futureFactory = ScalaFutureFactory
 


### PR DESCRIPTION
Update requests (such as adding docs) are now sent to the shard leader.

This adds the `isLeader` property to the `SolrServer`, which might
require some code changes if it's used by client code, such as filtering
fast servers in `FastestServerLB`. Since this is expected to be rarely
used so that the major version must not necessarily increased.