### PR TITLE
Add support for standard collection aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ be passed to `RoundRobinLB`/`FastestServerLB`).
 
 Solr Cloud is supported with the following properties / restrictions:
 
-* No Collection Aliases supported (a PR's welcome)
+* Standard collection aliases are supported, no support for (time) routed aliases (see also [Collections API / CreateAlias docs](https://lucene.apache.org/solr/guide/7_4/collections-api.html#createalias))
 * Can use a default collection, if this is not provided, per request the `SolrQuery` must specify
   the collection via the "collection" parameter.
 * New solr servers or solr servers that changed their state from inactive (e.g. down) to active can be tested

--- a/src/main/scala/io/ino/solrs/RetryPolicy.scala
+++ b/src/main/scala/io/ino/solrs/RetryPolicy.scala
@@ -1,6 +1,8 @@
 package io.ino.solrs
 
 import scala.annotation.tailrec
+import scala.util.Failure
+import scala.util.Success
 
 /**
  * Specifies a policy for retrying request failures.
@@ -76,9 +78,9 @@ object RetryPolicy {
         } else {
           val maybeServer = lb.solrServer(requestContext.r, preferred)
           maybeServer match {
-            case None => None
-            case Some(s) if s == server || requestContext.triedServers.contains(s) => findAvailable(round + 1)
-            case s@Some(_) => s
+            case Failure(_) => None
+            case Success(s) if s == server || requestContext.triedServers.contains(s) => findAvailable(round + 1)
+            case Success(s) => Some(s)
           }
         }
       }

--- a/src/main/scala/io/ino/solrs/SolrServer.scala
+++ b/src/main/scala/io/ino/solrs/SolrServer.scala
@@ -3,7 +3,7 @@ package io.ino.solrs
 final case class SolrServerId(url: String) extends AnyVal
 
 /**
- * Represents a solr host.
+ * Represents a solr host, or a shard replica in a SolrCloud setup.
  *
  * @param baseUrl the solr server's base url, must not end with a slash.
  */

--- a/src/main/scala/io/ino/solrs/Utils.scala
+++ b/src/main/scala/io/ino/solrs/Utils.scala
@@ -1,0 +1,18 @@
+package io.ino.solrs
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+object Utils {
+
+  implicit class OptionOps[A](opt: Option[A]) {
+
+    def toTry(msg: String): Try[A] = {
+      opt
+        .map(Success(_))
+        .getOrElse(Failure(new NoSuchElementException(msg)))
+    }
+  }
+
+}

--- a/src/test/resources/solr-home/collection2/conf
+++ b/src/test/resources/solr-home/collection2/conf
@@ -1,0 +1,1 @@
+../collection1/conf/

--- a/src/test/resources/solr-home/collection2/core.properties
+++ b/src/test/resources/solr-home/collection2/core.properties
@@ -1,0 +1,1 @@
+name=collection2

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
@@ -20,6 +20,7 @@ import scala.util.control.NonFatal
  * RetryPolicy.TryAvailableServers is needed because for a restarted server the status is not updated
  * fast enough.
  */
+//noinspection RedundantDefaultArgument
 class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventually with IntegrationPatience {
 
   private implicit val timeout: FiniteDuration = 5.second
@@ -38,7 +39,14 @@ class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventuall
   import io.ino.solrs.SolrUtils._
 
   override def beforeAll() {
-    solrRunner = SolrCloudRunner.start(2, List(SolrCollection("collection1", 2, 1)), Some("collection1"))
+    solrRunner = SolrCloudRunner.start(
+      numServers = 2,
+      collections = List(
+        SolrCollection("collection1", replicas = 2, shards = 1),
+        SolrCollection("collection2", replicas = 2, shards = 1)
+      ),
+      defaultCollection = Some("collection1")
+    )
     solrJClient = solrRunner.solrJClient
 
     solrServers = new CloudSolrServers(

--- a/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
@@ -158,7 +158,7 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
         val id = doc.getFieldValue("id").toString
         val route = id.substring(0, id.indexOf('!') + 1)
         val request = new QueryRequest(new SolrQuery("*:*").setParam(_ROUTE_, route))
-        cut.matching(request).map(_.withLeader(false)) should contain theSameElementsAs expectedServers.map(SolrServer(_, Enabled, isLeader = false))
+        cut.matching(request).get.map(_.withLeader(false)) should contain theSameElementsAs expectedServers.map(SolrServer(_, Enabled, isLeader = false))
       }
 
       // now stop a server
@@ -178,7 +178,7 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
             case serverUrl if serverUrl == solrServers.head.baseUrl => SolrServer(serverUrl, Failed, isLeader = false)
             case serverUrl => SolrServer(serverUrl, Enabled, isLeader = false)
           }
-          cut.matching(request).map(_.withLeader(false)) should contain theSameElementsAs expectedServersWithStatus
+          cut.matching(request).get.map(_.withLeader(false)) should contain theSameElementsAs expectedServersWithStatus
         }
 
     }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersIntegrationSpec.scala
@@ -55,7 +55,7 @@ class CloudSolrServersIntegrationSpec extends StandardFunSpec {
     // create a 2 node cluster with one collection that has 2 shards with 2 replicas
     solrRunner = SolrCloudRunner.start(
       numServers = 4,
-      cores = List(SolrCollection("collection1", replicas = 2, shards = 2)),
+      collections = List(SolrCollection("collection1", replicas = 2, shards = 2)),
       defaultCollection = Some("collection1")
     )
     solrJClient = solrRunner.solrJClient

--- a/src/test/scala/io/ino/solrs/RetryPolicySpec.scala
+++ b/src/test/scala/io/ino/solrs/RetryPolicySpec.scala
@@ -1,5 +1,6 @@
 package io.ino.solrs
 
+import io.ino.solrs.LoadBalancer.NoSolrServersAvailableException
 import io.ino.solrs.RetryPolicy._
 import io.ino.solrs.RetryDecision.Result
 import org.apache.solr.client.solrj.SolrQuery
@@ -8,6 +9,8 @@ import org.apache.solr.client.solrj.request.QueryRequest
 import org.scalatest.{FunSpec, Inside, Matchers}
 
 import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Try
 
 class RetryPolicySpec extends FunSpec with Matchers with Inside {
 
@@ -26,7 +29,7 @@ class RetryPolicySpec extends FunSpec with Matchers with Inside {
 
     it("should not retry when no servers available") {
       val lb = new LoadBalancer {
-        override def solrServer(r: SolrRequest[_], preferred: Option[SolrServer] = None): Option[SolrServer] = None
+        override def solrServer(r: SolrRequest[_], preferred: Option[SolrServer] = None): Try[SolrServer] = Failure(NoSolrServersAvailableException(Nil))
         override val solrServers = new StaticSolrServers(IndexedSeq.empty)
       }
       val retry = TryAvailableServers.shouldRetry(e, server1, RequestContext(q), lb)

--- a/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
@@ -1,10 +1,15 @@
 package io.ino.solrs
 
-import org.apache.solr.client.solrj.request.QueryRequest
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
+import org.apache.solr.client.solrj.request.QueryRequest
 import org.apache.solr.client.solrj.request.UpdateRequest
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 //noinspection RedundantDefaultArgument
 class RoundRobinLBSpec extends FunSpec with Matchers {
@@ -16,40 +21,40 @@ class RoundRobinLBSpec extends FunSpec with Matchers {
     it("should return None if no solr server matches") {
       val nonMatchingServers = new SolrServers {
         override def all: Seq[SolrServer] = Nil
-        override def matching(r: SolrRequest[_]): IndexedSeq[SolrServer] = Vector.empty
+        override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = Success(Vector.empty)
       }
       val cut = RoundRobinLB(nonMatchingServers)
 
-      cut.solrServer(q) should be (None)
+      cut.solrServer(q) shouldBe a[Failure[_]]
     }
 
     it("should return consecutive solr servers") {
       val cut = RoundRobinLB(IndexedSeq("host1", "host2"))
 
-      cut.solrServer(q) should be (Some(SolrServer("host2")))
-      cut.solrServer(q) should be (Some(SolrServer("host1")))
-      cut.solrServer(q) should be (Some(SolrServer("host2")))
-      cut.solrServer(q) should be (Some(SolrServer("host1")))
+      cut.solrServer(q) should be (Success(SolrServer("host2")))
+      cut.solrServer(q) should be (Success(SolrServer("host1")))
+      cut.solrServer(q) should be (Success(SolrServer("host2")))
+      cut.solrServer(q) should be (Success(SolrServer("host1")))
     }
 
     it("should only return active solr servers") {
       val servers = IndexedSeq(SolrServer("host1"), SolrServer("host2"))
       val cut = new RoundRobinLB(new StaticSolrServers(servers))
 
-      cut.solrServer(q) should be (Some(SolrServer("host2")))
-      cut.solrServer(q) should be (Some(SolrServer("host1")))
-      cut.solrServer(q) should be (Some(SolrServer("host2")))
+      cut.solrServer(q) should be (Success(SolrServer("host2")))
+      cut.solrServer(q) should be (Success(SolrServer("host1")))
+      cut.solrServer(q) should be (Success(SolrServer("host2")))
 
       servers(0).status = Disabled
-      cut.solrServer(q) should be (Some(SolrServer("host2")))
+      cut.solrServer(q) should be (Success(SolrServer("host2")))
 
       servers(0).status = Enabled
       servers(1).status = Failed
-      cut.solrServer(q) should be (Some(SolrServer("host1")))
-      cut.solrServer(q) should be (Some(SolrServer("host1")))
+      cut.solrServer(q) should be (Success(SolrServer("host1")))
+      cut.solrServer(q) should be (Success(SolrServer("host1")))
 
       servers(0).status = Disabled
-      cut.solrServer(q) should be (None)
+      cut.solrServer(q) shouldBe a[Failure[_]]
     }
 
     it("should return the active leader for update requests") {
@@ -60,13 +65,13 @@ class RoundRobinLBSpec extends FunSpec with Matchers {
 
       val q = new UpdateRequest()
 
-      cut.solrServer(q) should be (Some(server1))
-      cut.solrServer(q) should be (Some(server1))
-      cut.solrServer(q) should be (Some(server1))
+      cut.solrServer(q) should be (Success(server1))
+      cut.solrServer(q) should be (Success(server1))
+      cut.solrServer(q) should be (Success(server1))
 
       servers(0).status = Disabled
-      cut.solrServer(q) should be (Some(server2))
-      cut.solrServer(q) should be (Some(server2))
+      cut.solrServer(q) should be (Success(server2))
+      cut.solrServer(q) should be (Success(server2))
     }
 
     it("should consider the preferred server if active") {
@@ -75,11 +80,11 @@ class RoundRobinLBSpec extends FunSpec with Matchers {
 
       val preferred = Some(SolrServer("host2"))
 
-      cut.solrServer(q, preferred) should be (preferred)
-      cut.solrServer(q, preferred) should be (preferred)
+      cut.solrServer(q, preferred) should be (Success(preferred.get))
+      cut.solrServer(q, preferred) should be (Success(preferred.get))
 
       servers(1).status = Failed
-      cut.solrServer(q, preferred) should be (Some(SolrServer("host1")))
+      cut.solrServer(q, preferred) should be (Success(SolrServer("host1")))
     }
   }
 

--- a/src/test/scala/io/ino/solrs/SolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/SolrServersSpec.scala
@@ -17,7 +17,7 @@ class SolrServersSpec extends FunSpec with Matchers with FutureAwaits {
       val solrServers = IndexedSeq(SolrServer("host1"), SolrServer("host2"))
       val cut = new StaticSolrServers(solrServers)
 
-      val found = cut.matching(q)
+      val found = cut.matching(q).get
 
       found should contain theSameElementsAs solrServers
     }
@@ -40,13 +40,13 @@ class SolrServersSpec extends FunSpec with Matchers with FutureAwaits {
         }
       }
       cut.all should have size (0)
-      val iterator = cut.matching(q)
+      val iterator = cut.matching(q).get
       iterator should have size 0
 
       await(cut.reload())
 
       cut.all should have size (2)
-      cut.matching(q) should contain theSameElementsAs Seq(SolrServer("host1"), SolrServer("host2"))
+      cut.matching(q).get should contain theSameElementsAs Seq(SolrServer("host1"), SolrServer("host2"))
 
     }
   }


### PR DESCRIPTION
This adds support for standard collection aliases (in contrast to (time) routes aliases, see also the [Collections API / CREATEALIAS docs](https://lucene.apache.org/solr/guide/7_4/collections-api.html#createalias)).

While the implementation uses only the first aliased collection to resolve possible replica urls for the query, on server side solr will still query all (multiple) aliased collections and return the combined result.

Closes #31, #39