### PR TITLE
Optimize routing according to shards.preference=replica.type

### DIFF
--- a/src/main/scala/io/ino/solrs/SolrServer.scala
+++ b/src/main/scala/io/ino/solrs/SolrServer.scala
@@ -1,13 +1,17 @@
 package io.ino.solrs
 
+import io.ino.solrs.SolrServer.fixUrl
+import org.apache.solr.common.cloud.Replica
+import org.apache.solr.common.cloud.ZkStateReader
+
 final case class SolrServerId(url: String) extends AnyVal
 
 /**
- * Represents a solr host, or a shard replica in a SolrCloud setup.
+ * Represents a solr host, for a SolrCloud setup there's the specialized [[ShardReplica]].
  *
  * @param baseUrl the solr server's base url, must not end with a slash.
  */
-class SolrServer(val baseUrl: String, val isLeader: Boolean) {
+class SolrServer(val baseUrl: String) {
 
   require(!baseUrl.endsWith("/"), s"baseUrl must not end with '/', but was '$baseUrl'.")
 
@@ -18,33 +22,66 @@ class SolrServer(val baseUrl: String, val isLeader: Boolean) {
   @volatile
   var status: ServerStatus = Enabled
 
-  def withLeader(isLeader: Boolean): SolrServer =
-    if(isLeader == this.isLeader) this
-    else SolrServer(baseUrl, status, isLeader)
-
   def isEnabled: Boolean = status == Enabled
 
-  override def toString: String = s"SolrServer($baseUrl, $status, $isLeader)"
+  override def toString: String = s"SolrServer($baseUrl, $status)"
 
   override def equals(other: Any): Boolean = other match {
-    case that: SolrServer => isLeader == that.isLeader && status == that.status && baseUrl == that.baseUrl
+    case that: SolrServer => status == that.status && baseUrl == that.baseUrl
     case _ => false
   }
 
-  override def hashCode(): Int = isLeader.hashCode() + status.hashCode() + baseUrl.hashCode
+  override def hashCode(): Int = status.hashCode() + baseUrl.hashCode
 }
 
 object SolrServer {
 
-  def apply(baseUrl: String, isLeader: Boolean = false): SolrServer = new SolrServer(fixUrl(baseUrl), isLeader)
+  def apply(baseUrl: String): SolrServer = new SolrServer(fixUrl(baseUrl))
 
   private[solrs] def fixUrl(baseUrl: String): String = if (baseUrl.endsWith("/")) baseUrl.dropRight(1) else baseUrl
 
-  def apply(baseUrl: String, status: ServerStatus, isLeader: Boolean): SolrServer = {
-    val res = SolrServer(baseUrl, isLeader)
+  def apply(baseUrl: String, status: ServerStatus): SolrServer = {
+    val res = SolrServer(baseUrl)
     res.status = status
     res
   }
+}
+
+class ShardReplica(baseUrl: String, underlying: Replica) extends SolrServer(baseUrl) {
+
+  // according to org.apache.solr.common.cloud.ZkCoreNodeProps.isLeader
+  val isLeader: Boolean = underlying.containsKey(ZkStateReader.LEADER_PROP)
+
+  val replicaType: Replica.Type = underlying.getType
+
+  override def toString: String = s"ShardReplica($baseUrl, $status, $replicaType, $isLeader)"
+
+  override def equals(other: Any): Boolean = super.equals(other) && (other match {
+    case that: ShardReplica => replicaType == that.replicaType && isLeader == that.isLeader
+    case _ => false
+  })
+
+  override def hashCode(): Int = replicaType.hashCode() + isLeader.hashCode() + super.hashCode()
+
+}
+
+object ShardReplica {
+
+  def apply(baseUrl: String, underlying: Replica): ShardReplica = {
+    val res = new ShardReplica(fixUrl(baseUrl), underlying)
+    res.status = underlying.getState match {
+      case Replica.State.ACTIVE => Enabled
+      case Replica.State.RECOVERING => Disabled
+      case Replica.State.RECOVERY_FAILED => Failed
+      case Replica.State.DOWN => Failed
+    }
+    res
+  }
+
+  private[solrs] def findLeader(servers: Iterable[SolrServer]): Option[ShardReplica] = servers.collectFirst {
+    case s: ShardReplica if s.isLeader => s
+  }
+
 }
 
 sealed trait ServerStatus

--- a/src/main/scala/io/ino/solrs/regex.sc
+++ b/src/main/scala/io/ino/solrs/regex.sc
@@ -1,0 +1,5 @@
+val p = "foo:(a|b|x)"r
+
+p.findAllMatchIn("foo:a,foo:b,bar:c,foo:x").foreach { m =>
+  println(m.group(1))
+}

--- a/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
@@ -2,6 +2,7 @@ package io.ino.solrs
 
 import java.nio.file.{Files, Paths}
 
+import io.ino.solrs.Fixtures.shardReplica
 import org.apache.solr.common.cloud.ClusterState
 import org.scalatest._
 
@@ -19,24 +20,24 @@ class CloudSolrServersSpec extends FunSpec with Matchers {
 
       val events = CloudSolrServers.diff(
         oldState = Map(
-          "col1" -> Seq(SolrServer("h10", Enabled, isLeader = true)),
-          "col2" -> Seq(SolrServer("h20", Enabled, isLeader = true), SolrServer("h21", Enabled, isLeader = false), SolrServer("h22", Disabled, isLeader = false))
+          "col1" -> Seq(shardReplica("h10", Enabled, isLeader = true)),
+          "col2" -> Seq(shardReplica("h20", Enabled, isLeader = true), shardReplica("h21", Enabled, isLeader = false), shardReplica("h22", Disabled, isLeader = false))
         ),
         newState = Map(
-          "col2" -> Seq(SolrServer("h21", Enabled, isLeader = true), SolrServer("h22", Enabled, isLeader = false), SolrServer("h23", Enabled, isLeader = false)),
-          "col3" -> Seq(SolrServer("h30", Enabled, isLeader = false))
+          "col2" -> Seq(shardReplica("h21", Enabled, isLeader = true), shardReplica("h22", Enabled, isLeader = false), shardReplica("h23", Enabled, isLeader = false)),
+          "col3" -> Seq(shardReplica("h30", Enabled, isLeader = false))
         )
       )
 
       implicit val solrServerOrd: Ordering[SolrServer] = Ordering[String].on[SolrServer](s => s.baseUrl)
 
       events should contain theSameElementsAs Seq(
-        Removed(SolrServer("h10", Enabled, isLeader = true), "col1"),
-        Removed(SolrServer("h20", Enabled, isLeader = true), "col2"),
-        StateChanged(SolrServer("h21", Enabled, isLeader = false), SolrServer("h21", Enabled, isLeader = true), "col2"),
-        StateChanged(SolrServer("h22", Disabled, isLeader = false), SolrServer("h22", Enabled, isLeader = false), "col2"),
-        Added(SolrServer("h23", Enabled, isLeader = false), "col2"),
-        Added(SolrServer("h30", Enabled, isLeader = false), "col3")
+        Removed(shardReplica("h10", Enabled, isLeader = true), "col1"),
+        Removed(shardReplica("h20", Enabled, isLeader = true), "col2"),
+        StateChanged(shardReplica("h21", Enabled, isLeader = false), shardReplica("h21", Enabled, isLeader = true), "col2"),
+        StateChanged(shardReplica("h22", Disabled, isLeader = false), shardReplica("h22", Enabled, isLeader = false), "col2"),
+        Added(shardReplica("h23", Enabled, isLeader = false), "col2"),
+        Added(shardReplica("h30", Enabled, isLeader = false), "col3")
       )
 
     }
@@ -49,12 +50,12 @@ class CloudSolrServersSpec extends FunSpec with Matchers {
 
       val collectionToServers = CloudSolrServers.getCollections(cs)
       collectionToServers("my-collection").servers should contain allOf(
-        SolrServer("http://server1:8983/solr/my-collection_shard1_replica1", Enabled, isLeader = true),
-        SolrServer("http://server2:8983/solr/my-collection_shard1_replica2", Enabled, isLeader = false),
-        SolrServer("http://server3:8983/solr/my-collection_shard2_replica1", Enabled, isLeader = true),
-        SolrServer("http://server4:8983/solr/my-collection_shard2_replica2", Enabled, isLeader = false),
-        SolrServer("http://server5:8983/solr/my-collection_shard3_replica1", Enabled, isLeader = true),
-        SolrServer("http://server6:8983/solr/my-collection_shard3_replica2", Enabled, isLeader = false))
+        shardReplica("http://server1:8983/solr/my-collection_shard1_replica1", Enabled, isLeader = true),
+        shardReplica("http://server2:8983/solr/my-collection_shard1_replica2", Enabled, isLeader = false),
+        shardReplica("http://server3:8983/solr/my-collection_shard2_replica1", Enabled, isLeader = true),
+        shardReplica("http://server4:8983/solr/my-collection_shard2_replica2", Enabled, isLeader = false),
+        shardReplica("http://server5:8983/solr/my-collection_shard3_replica1", Enabled, isLeader = true),
+        shardReplica("http://server6:8983/solr/my-collection_shard3_replica2", Enabled, isLeader = false))
     }
 
   }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
@@ -69,7 +69,8 @@ class CloudSolrServersUninitializedIntegrationSpec extends StandardFunSpec {
       solrRunner = SolrCloudRunner.start(2, List(SolrCollection("collection1", 2, 1)), Some("collection1"), Some(zkPort))
 
       eventually(Timeout(20 seconds)) {
-        cut.get.all.map(_.withLeader(false)) should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled, isLeader = false))
+        import Equalities.solrServerStatusEquality
+        cut.get.all should contain theSameElementsAs solrServerUrls.map(SolrServer(_, Enabled))
       }
 
     }

--- a/src/test/scala/io/ino/solrs/Equalities.scala
+++ b/src/test/scala/io/ino/solrs/Equalities.scala
@@ -1,0 +1,26 @@
+package io.ino.solrs
+
+import org.scalactic
+import org.scalactic.Equality
+import org.scalactic.Uniformity
+
+object Equalities {
+
+  /**
+    * Reduces a [[ShardReplica]] to [[SolrServer]], so that only url and status are compared
+    * (ignoring [[ShardReplica]]'s `isLeader` and `replicaType`).
+    */
+  implicit val solrServerStatusEquality: Equality[SolrServer] = scalactic.Equality(new Uniformity[SolrServer] {
+
+    override def normalizedOrSame(b: Any): Any = b match {
+      case s: ShardReplica => SolrServer(s.baseUrl, s.status)
+      case s: SolrServer => s
+    }
+
+    override def normalizedCanHandle(b: Any): Boolean = b.isInstanceOf[SolrServer]
+
+    override def normalized(a: SolrServer): SolrServer = normalizedOrSame(a).asInstanceOf[SolrServer]
+
+  })
+
+}

--- a/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
@@ -2,6 +2,7 @@ package io.ino.solrs
 
 import java.util.concurrent.TimeUnit
 
+import io.ino.solrs.Fixtures.shardReplica
 import io.ino.solrs.SolrMatchers.hasQuery
 import io.ino.time.Clock
 import io.ino.time.Clock.MutableClock
@@ -88,10 +89,12 @@ class FastestServerLBSpec extends StandardFunSpec {
     }
 
     it("should return the active leader for update requests") {
-      val server1 = SolrServer("host1", isLeader = true)
-      val server2 = SolrServer("host2", isLeader = false)
+      val server1 = shardReplica("host1", isLeader = true)
+      val server2 = shardReplica("host2", isLeader = false)
       val servers = IndexedSeq(server1, server2)
-      val cut = newDynamicLB(new StaticSolrServers(servers))
+      val cut = newDynamicLB(new StaticSolrServers(servers) {
+        override def findLeader(servers: Iterable[SolrServer]): Option[ShardReplica] = ShardReplica.findLeader(servers)
+      })
 
       val r = new UpdateRequest()
 

--- a/src/test/scala/io/ino/solrs/Fixtures.scala
+++ b/src/test/scala/io/ino/solrs/Fixtures.scala
@@ -5,7 +5,12 @@ import org.apache.solr.common.cloud.ZkStateReader
 
 object Fixtures {
 
-  def shardReplica(baseUrl: String, status: ServerStatus = Enabled, isLeader: Boolean): ShardReplica = {
+  def shardReplica(
+      baseUrl: String,
+      status: ServerStatus = Enabled,
+      replicaType: Replica.Type = Replica.Type.NRT,
+      isLeader: Boolean = false
+    ): ShardReplica = {
     import scala.collection.JavaConverters.mapAsJavaMapConverter
     val leaderProps: Map[String, AnyRef] = if(isLeader) Map(ZkStateReader.LEADER_PROP -> true.toString) else Map.empty
     val replicaStatus = status match {
@@ -14,7 +19,8 @@ object Fixtures {
       case Failed => Replica.State.RECOVERY_FAILED
     }
     val replica = new Replica(baseUrl, (Map[String, AnyRef](
-      ZkStateReader.STATE_PROP -> replicaStatus.toString
+      ZkStateReader.STATE_PROP -> replicaStatus.toString,
+      ZkStateReader.REPLICA_TYPE -> replicaType.name()
     ) ++ leaderProps).asJava)
     ShardReplica(baseUrl, replica)
   }

--- a/src/test/scala/io/ino/solrs/Fixtures.scala
+++ b/src/test/scala/io/ino/solrs/Fixtures.scala
@@ -1,0 +1,22 @@
+package io.ino.solrs
+
+import org.apache.solr.common.cloud.Replica
+import org.apache.solr.common.cloud.ZkStateReader
+
+object Fixtures {
+
+  def shardReplica(baseUrl: String, status: ServerStatus = Enabled, isLeader: Boolean): ShardReplica = {
+    import scala.collection.JavaConverters.mapAsJavaMapConverter
+    val leaderProps: Map[String, AnyRef] = if(isLeader) Map(ZkStateReader.LEADER_PROP -> true.toString) else Map.empty
+    val replicaStatus = status match {
+      case Enabled => Replica.State.ACTIVE
+      case Disabled => Replica.State.RECOVERING
+      case Failed => Replica.State.RECOVERY_FAILED
+    }
+    val replica = new Replica(baseUrl, (Map[String, AnyRef](
+      ZkStateReader.STATE_PROP -> replicaStatus.toString
+    ) ++ leaderProps).asJava)
+    ShardReplica(baseUrl, replica)
+  }
+
+}

--- a/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
@@ -1,5 +1,6 @@
 package io.ino.solrs
 
+import io.ino.solrs.Fixtures.shardReplica
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.request.QueryRequest
@@ -58,10 +59,12 @@ class RoundRobinLBSpec extends FunSpec with Matchers {
     }
 
     it("should return the active leader for update requests") {
-      val server1 = SolrServer("host1", isLeader = true)
-      val server2 = SolrServer("host2", isLeader = false)
+      val server1 = shardReplica("host1", isLeader = true)
+      val server2 = shardReplica("host2", isLeader = false)
       val servers = IndexedSeq(server1, server2)
-      val cut = new RoundRobinLB(new StaticSolrServers(servers))
+      val cut = new RoundRobinLB(new StaticSolrServers(servers) {
+        override def findLeader(servers: Iterable[SolrServer]): Option[ShardReplica] = ShardReplica.findLeader(servers)
+      })
 
       val q = new UpdateRequest()
 

--- a/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
@@ -5,6 +5,13 @@ import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.request.QueryRequest
 import org.apache.solr.client.solrj.request.UpdateRequest
+import org.apache.solr.common.cloud.Replica
+import org.apache.solr.common.cloud.Replica.Type.NRT
+import org.apache.solr.common.cloud.Replica.Type.PULL
+import org.apache.solr.common.cloud.Replica.Type.TLOG
+import org.apache.solr.common.params.ShardParams
+import org.apache.solr.common.params.ShardParams.SHARDS_PREFERENCE
+import org.apache.solr.common.params.ShardParams.SHARDS_PREFERENCE_REPLICA_TYPE
 import org.scalatest.FunSpec
 import org.scalatest.Matchers
 
@@ -75,6 +82,39 @@ class RoundRobinLBSpec extends FunSpec with Matchers {
       servers(0).status = Disabled
       cut.solrServer(q) should be (Success(server2))
       cut.solrServer(q) should be (Success(server2))
+    }
+
+    it("should return replicas matching the given shard preferences / replica type") {
+      val server1 = shardReplica("host1", replicaType = NRT)
+      val server2 = shardReplica("host2", replicaType = TLOG)
+      val server3 = shardReplica("host3", replicaType = PULL)
+      val servers = IndexedSeq(server1, server2, server3)
+      val cut = new RoundRobinLB(new StaticSolrServers(servers))
+
+      // shards.preference=replica.location:local,replica.type:PULL,replica.type:TLOG
+      def q(replicaTypes: Replica.Type*) = new QueryRequest(
+        new SolrQuery("foo")
+          .setParam(
+            SHARDS_PREFERENCE,
+            "replica.location:local," + // just some noice to test the parsing
+            replicaTypes.mkString(s"$SHARDS_PREFERENCE_REPLICA_TYPE:", s",$SHARDS_PREFERENCE_REPLICA_TYPE:", ""
+          )))
+
+      // don't test expecing server1, 2, 3 since this would be the default RR result anyways...
+      cut.solrServer(q(PULL)) should be (Success(server3))
+      cut.solrServer(q(PULL)) should be (Success(server3))
+      cut.solrServer(q(TLOG)) should be (Success(server2))
+      cut.solrServer(q(TLOG)) should be (Success(server2))
+      cut.solrServer(q(NRT)) should be (Success(server1))
+      cut.solrServer(q(NRT)) should be (Success(server1))
+
+      cut.solrServer(q(TLOG, PULL)) should (be (Success(server2)) or be (Success(server3)))
+      cut.solrServer(q(PULL, TLOG)) should (be (Success(server2)) or be (Success(server3)))
+      cut.solrServer(q(NRT, PULL)) should (be (Success(server1)) or be (Success(server3)))
+      cut.solrServer(q(PULL, NRT)) should (be (Success(server1)) or be (Success(server3)))
+
+      servers(0).status = Disabled
+      cut.solrServer(q(NRT, PULL)) shouldBe Success(server3)
     }
 
     it("should consider the preferred server if active") {


### PR DESCRIPTION
* Introduce `ShardReplica` as specialization of `SolrServer`
* Optimize routing according to shards.preference=replica.type
  
  This adds optimized routing to both `RoundRobinLB` and `FastestServerLB`
    taking given replica type preferences into account (expressed via
    `shards.preference=replica.type`), see also [shards.preference docs](https://lucene.apache.org/solr/guide/7_4/distributed-requests.html#shards-preference-parameter).
    
    While Solr would do this already on server side automatically, this can
    save unnecessary additional network roundtrips.