### PR TITLE
Enable 'raw' queries by overriding default responseparser per request

### DIFF
--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -600,7 +600,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   private[solrs] def doExecute[T <: SolrResponse : SolrResponseFactory](solrServer: SolrServer, r: SolrRequest[_ <: T]): Future[T] = {
 
     val wparams = new ModifiableSolrParams(r.getParams)
-    if (responseParser != null) {
+    if (responseParser != null && r.getResponseParser == null) {
       wparams.set(CommonParams.WT, responseParser.getWriterType)
       wparams.set(CommonParams.VERSION, responseParser.getVersion)
     }
@@ -677,14 +677,14 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   protected def toSolrResponse[T <: SolrResponse : SolrResponseFactory](r: SolrRequest[_ <: T], response: Response, url: String, startTime: Long)(implicit server: SolrServer): T = {
     var rsp: NamedList[Object] = null
 
-    withResponseParser(r)(validateResponse(response, _))
+    withResponseParserFromRequest(r)(validateResponse(response, _))
 
     val httpStatus = response.getStatusCode
 
     try {
       val charset = getContentCharSet(response.getContentType).orNull
 
-      rsp = withResponseParser(r)(_.processResponse(response.getResponseBodyAsStream, charset))
+      rsp = withResponseParserFromRequest(r)(_.processResponse(response.getResponseBodyAsStream, charset))
 
     } catch {
       case NonFatal(e) =>
@@ -707,7 +707,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   }
 
 
-  private def withResponseParser[T <: SolrResponse, R](r: SolrRequest[_ <: T])(f:ResponseParser => R): R = {
+  private def withResponseParserFromRequest[T <: SolrResponse, R](r: SolrRequest[_ <: T])(f:ResponseParser => R): R = {
     f(Option(r.getResponseParser).getOrElse(responseParser))
   }
 

--- a/src/main/scala/io/ino/solrs/SolrResponseFactory.scala
+++ b/src/main/scala/io/ino/solrs/SolrResponseFactory.scala
@@ -1,7 +1,7 @@
 package io.ino.solrs
 
 import org.apache.solr.client.solrj.request.{QueryRequest, SolrPing, UpdateRequest}
-import org.apache.solr.client.solrj.response.{QueryResponse, SolrPingResponse, UpdateResponse}
+import org.apache.solr.client.solrj.response.{QueryResponse, SimpleSolrResponse, SolrPingResponse, UpdateResponse}
 import org.apache.solr.client.solrj.{SolrRequest, SolrResponse}
 
 trait SolrResponseFactory[T <: SolrResponse] {
@@ -18,6 +18,9 @@ object SolrResponseFactory {
 
   implicit val queryResponseFactory: SolrResponseFactory[QueryResponse] =
     instance(_ => new QueryResponse(null))
+
+  implicit val simpleSolrResponseFactory: SolrResponseFactory[SimpleSolrResponse] =
+    instance(_ => new SimpleSolrResponse)
 
   implicit val updateResponseFactory: SolrResponseFactory[UpdateResponse] =
     instance(_ => new UpdateResponse)

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -7,8 +7,8 @@ import org.asynchttpclient.DefaultAsyncHttpClient
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.SolrResponse
-import org.apache.solr.client.solrj.impl.XMLResponseParser
-import org.apache.solr.client.solrj.request.QueryRequest
+import org.apache.solr.client.solrj.impl.{NoOpResponseParser, XMLResponseParser}
+import org.apache.solr.client.solrj.request.{GenericSolrRequest, QueryRequest}
 import org.apache.solr.client.solrj.response.QueryResponse
 import org.mockito.Matchers._
 import org.mockito.Mockito.verify
@@ -22,6 +22,8 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.xml.XML
 
 class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
 
@@ -108,6 +110,26 @@ class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
       val response = solr.query(new SolrQuery("cat:cat1"))
 
       await(response).getResults.getNumFound should be (2)
+
+      solr.shutdown()
+    }
+
+    it("should allow to override the response parser per request") {
+
+      val solr = AsyncSolrClient.Builder(solrUrl).withResponseParser(new XMLResponseParser()).build
+
+      val request = new GenericSolrRequest(
+      SolrRequest.METHOD.POST,
+      null,
+        new SolrQuery("cat:cat1").add("wt", "xml")
+      )
+      request.setResponseParser(new NoOpResponseParser)
+
+      val response = solr.execute(request)
+
+      var xml = XML.loadString(await(response).getResponse.get("response").toString)
+
+      (xml \ "result" \ "@numFound").text.toInt should be (2)
 
       solr.shutdown()
     }

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -116,7 +116,7 @@ class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
 
     it("should allow to override the response parser per request") {
 
-      val solr = AsyncSolrClient.Builder(solrUrl).withResponseParser(new XMLResponseParser()).build
+      val solr = AsyncSolrClient.Builder(solrUrl).build
 
       val request = new GenericSolrRequest(
       SolrRequest.METHOD.POST,


### PR DESCRIPTION
I am looking forward to integrate official solrs releases again hopefully in the near future. Since I had to support existing frameworks relying on XML and JSON responses, solrs official QueryResponse was not an option. In order to still use solrs clustering capabilities, I had to find a way to get arbitrary response formats from solrs. I am aware, that there is an alternative solution available: creating new client instances for every response format. The reason for not going with that, was the additional IO caused by every new client instance for keeping the cluster state up-to-date.