### PR TITLE
Support for multiple collections in the 'collection' query param

### DIFF
--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -271,7 +271,7 @@ class CloudSolrServers[F[_]](zkHost: String,
    */
   override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = {
     val params = r.getParams
-    val collection = Option(params.get("collection")).orElse(defaultCollection).getOrElse(
+    val collection = Option(params.get("collection")).orElse(defaultCollection).map(_.split(",")(0)).getOrElse(
       throw new SolrServerException("No collection param specified on request and no default collection has been set.")
     )
     // - resolveAliases returns the input if no alias exists


### PR DESCRIPTION
When choosing the server use the first collection from a comma-separated list when there are multiple in the `collection` query param or default collection