### PR TITLE
Adding support for Scala 2.13

### DIFF
--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -271,7 +271,7 @@ class CloudSolrServers[F[_]](zkHost: String,
    */
   override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = {
     val params = r.getParams
-    val collection = Option(params.get("collection")).orElse(defaultCollection).getOrElse(
+    val collection = Option(params.get("collection")).orElse(defaultCollection).map(_.split(",")(0)).getOrElse(
       throw new SolrServerException("No collection param specified on request and no default collection has been set.")
     )
     // - resolveAliases returns the input if no alias exists


### PR DESCRIPTION
## Changelog
- Added support for Scala 2.13

## Questions / ToDo
- Removed support for Scala 2.11. Do we still need to support it?
- Updated `.travis.yml`. Do I need to change anything else?
- Still using old `scala.collections.JavaConverters` methods.
  - Unit tests have been changed to use `scala.jdk.CollectionConverters`, though
- Should this be version `2.3.1`, or `2.4.0`?