### PR TITLE
Adding support for Scala 2.13

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,1 @@
+maxColumn=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 
 scala:
-   - 2.11.12
    - 2.12.8 # remember to update/check the deploy condition below!
+   - 2.13.1
 
 jdk:
    - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ scmInfo := Some(ScmInfo(url("https://github.com/inoio/solrs"), "git@github.com:i
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+crossScalaVersions := Seq("2.12.8", "2.13.1")
 
 scalacOptions ++= Seq(
   "-unchecked",
@@ -56,7 +56,7 @@ libraryDependencies ++= Seq(
   // Cloud testing, solr-core for ZkController (upconfig)
   "org.apache.solr"         % "solr-core"         % solrVersion % "test",
   "org.apache.solr"         % "solr-test-framework" % solrVersion % "test",
-  "com.twitter"            %% "util-core"         % "19.5.1" % "optional",
+  "com.twitter"            %% "util-core"         % "19.10.0" % "optional",
   "commons-logging"         % "commons-logging"   % "1.2"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 // use a newer version of paradox (site would pull in automatically an older version)
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.3.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.7")
 // addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.4.0")
 
 /*

--- a/src/main/java/io/ino/solrs/MapConverter.java
+++ b/src/main/java/io/ino/solrs/MapConverter.java
@@ -1,0 +1,15 @@
+package io.ino.solrs;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MapConverter {
+    public static Map<String, List<String>> convert(Map<String, String[]> params) {
+        Map<String, List<String>> result = new HashMap<>();
+        params.forEach((key, value) -> result.put(key, Arrays.asList(value)));
+
+        return result;
+    }
+}

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -38,11 +38,11 @@ You must add the library to the dependencies of the build file:
     
 @@dependency[sbt,Maven,Gradle] {
   group="io.ino"
-  artifact="solrs_2.11"
+  artifact="solrs_2.12"
   version="$project.version$"
 }
 
-solrs is published to maven central for both scala 2.11 and 2.12.
+solrs is published to maven central for both scala 2.11 (up to version 2.3.0), 2.12 and 2.13.
 
 ## License
 

--- a/src/main/scala/io/ino/concurrent/Execution.scala
+++ b/src/main/scala/io/ino/concurrent/Execution.scala
@@ -5,8 +5,13 @@ import scala.concurrent.ExecutionContext
 object Execution {
 
   val sameThreadContext: ExecutionContext = new ExecutionContext {
-    def reportFailure(t: Throwable) { t.printStackTrace() }
-    def execute(runnable: Runnable) {runnable.run()}
+    def reportFailure(t: Throwable) : Unit = {
+      t.printStackTrace()
+    }
+
+    def execute(runnable: Runnable) : Unit = {
+      runnable.run()
+    }
   }
 
   object Implicits {

--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -637,7 +637,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
       }.getOrElse {
         // POST/PUT with FORM data
         val req = if (r.getMethod == POST) httpClient.preparePost(url) else httpClient.preparePut(url)
-        req.setFormParams(wparams.getMap.asScala.mapValues(asList[String](_: _*)).asJava)
+        req.setFormParams(MapConverter.convert(wparams.getMap))
       }
     }
     val request = requestBuilder.addHeader("User-Agent", agent).build()
@@ -654,7 +654,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
           response
         }
 
-        override def onThrowable(t: Throwable) {
+        override def onThrowable(t: Throwable): Unit = {
           metrics.countException
           promise.failure(t)
         }
@@ -712,7 +712,7 @@ class AsyncSolrClient[F[_]] protected (private[solrs] val loadBalancer: LoadBala
   }
 
   @throws[RemoteSolrException]
-  private def validateResponse(response: Response, responseParser: ResponseParser)(implicit server: SolrServer) {
+  private def validateResponse(response: Response, responseParser: ResponseParser)(implicit server: SolrServer): Unit = {
     validateMimeType(responseParser.getContentType, response)
 
     val httpStatus = response.getStatusCode

--- a/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
@@ -494,7 +494,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     * @return an [[org.apache.solr.client.solrj.response.UpdateResponse UpdateResponse]] containing the response
     *         from the server
     */
-  def deleteByIds(ids: util.List[String]): CompletionStage[UpdateResponse] = super.deleteByIds(ids = ids.asScala)
+  def deleteByIds(ids: util.List[String]): CompletionStage[UpdateResponse] = super.deleteByIds(ids = ids.asScala.toSeq)
 
   /**
     * Deletes a list of documents by unique ID, specifying max time before commit
@@ -505,7 +505,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *         from the server
     */
   def deleteByIds(ids: util.List[String], commitWithinMs: Int): CompletionStage[UpdateResponse] =
-    super.deleteByIds(ids = ids.asScala, commitWithinMs = commitWithinMs)
+    super.deleteByIds(ids = ids.asScala.toSeq, commitWithinMs = commitWithinMs)
 
   /**
     * Deletes a list of documents by unique ID, specifying max time before commit
@@ -516,7 +516,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *         from the server
     */
   def deleteByIds(collection: String, ids: util.List[String]): CompletionStage[UpdateResponse] =
-    super.deleteByIds(Option(collection), ids.asScala)
+    super.deleteByIds(Option(collection), ids.asScala.toSeq)
 
   /**
     * Deletes a list of documents by unique ID, specifying max time before commit
@@ -528,7 +528,7 @@ class JavaAsyncSolrClient(override private[solrs] val loadBalancer: LoadBalancer
     *         from the server
     */
   def deleteByIds(collection: String, ids: util.List[String], commitWithinMs: Int): CompletionStage[UpdateResponse] =
-    super.deleteByIds(Option(collection), ids.asScala, commitWithinMs)
+    super.deleteByIds(Option(collection), ids.asScala.toSeq, commitWithinMs)
 
   /**
     * Deletes documents from the index based on a query, specifying max time before commit

--- a/src/main/scala/io/ino/solrs/PerformanceStats.scala
+++ b/src/main/scala/io/ino/solrs/PerformanceStats.scala
@@ -114,8 +114,10 @@ class PerformanceStats(val solrServer: SolrServer, initialPredictedResponseTime:
           }
         }
       }
-      val averagesByQueryClass = countsAndDurationsByQueryClass.mapValues { case (count, durationSum) => durationSum / count }
-      requestAveragesPer10Seconds.update(idx, averagesByQueryClass)
+
+      requestAveragesPer10Seconds.update(idx, countsAndDurationsByQueryClass.toSeq.map {
+        case (queryClass, (count, durationSum)) => (queryClass, durationSum / count)
+      }.toMap)
     }
   }
 

--- a/src/main/scala/io/ino/solrs/ServerStateObserver.scala
+++ b/src/main/scala/io/ino/solrs/ServerStateObserver.scala
@@ -66,10 +66,10 @@ class PingStatusObserver[F[_]](solrServers: SolrServers, httpClient: AsyncHttpCl
       })
       promise.future
     }
-    FutureFactory.sequence(futures).map(_ => Unit)
+    FutureFactory.sequence(futures).map(_ => ())
   }
 
-  private def updateServerStatus(server: SolrServer, response: Response, url: String) {
+  private def updateServerStatus(server: SolrServer, response: Response, url: String): Unit = {
     if (response.getStatusCode != 200) {
       logger.warn(s"Got ping response status != 200 (${response.getStatusCode}) from $url, with response '${new String(response.getResponseBodyAsBytes)}'")
       server.status = Failed

--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -24,7 +24,6 @@ import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.Response
 import org.slf4j.LoggerFactory
 
-import scala.collection.breakOut
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import scala.util.Failure
@@ -33,17 +32,18 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
- * Provides the list of solr servers.
- */
+  * Provides the list of solr servers.
+  */
 trait SolrServers {
+
   /**
-   * The currently known solr servers.
-   */
+    * The currently known solr servers.
+    */
   def all: Seq[SolrServer]
 
   /**
-   * Determines Solr servers matching the given solr request (e.g. based on the "collection" param).
-   */
+    * Determines Solr servers matching the given solr request (e.g. based on the "collection" param).
+    */
   def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]]
 
   /**
@@ -57,11 +57,13 @@ class StaticSolrServers(override val all: IndexedSeq[SolrServer]) extends SolrSe
   override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = Success(all)
 }
 object StaticSolrServers {
-  def apply(baseUrls: IndexedSeq[String]): StaticSolrServers = new StaticSolrServers(baseUrls.map(SolrServer(_)))
+  def apply(baseUrls: IndexedSeq[String]): StaticSolrServers =
+    new StaticSolrServers(baseUrls.map(SolrServer(_)))
 
   /* Java API */
   import scala.collection.JavaConverters._
-  def create(baseUrls: java.lang.Iterable[String]): StaticSolrServers = apply(baseUrls.asScala.toIndexedSeq)
+  def create(baseUrls: java.lang.Iterable[String]): StaticSolrServers =
+    apply(baseUrls.asScala.toIndexedSeq)
 }
 
 import java.util.concurrent.TimeUnit
@@ -82,11 +84,11 @@ private class ZkClusterStateUpdateTF extends ThreadFactory {
 }
 
 trait StateChangeObserver {
-  def onStateChange(event: StateChange)
+  def onStateChange(event: StateChange): Unit
 }
 
 trait ServerStateChangeObservable {
-  def register(listener: StateChangeObserver)
+  def register(listener: StateChangeObserver): Unit
 }
 
 object ServerStateChangeObservable {
@@ -99,25 +101,28 @@ object ServerStateChangeObservable {
 }
 
 /**
- * Provides servers based on information from from ZooKeeper. Uses the ZkStateReader to read the ZK cluster state,
- * which is also used by solrj's CloudSolrServer. While ZkStateReader uses ZK Watches to get cluster state changes
- * from ZK, we're regularly updating our internal state by reading the cluster state from ZkStateReader.
- *
- * @param zkHost The zkHost string, in $host:$port format, multiple hosts are specified comma separated
- * @param zkClientTimeout The zk session timeout (passed to ZkStateReader)
- * @param zkConnectTimeout The zk connection timeout (passed to ZkStateReader),
- *                         also used for ZkStateReader initialization attempt interval.
- *                         Note that we're NOT stopping connection retries after connect timeout!
- * @param clusterStateUpdateInterval Used for pulling the ClusterState from ZkStateReader
- * @param defaultCollection Optional default collection to use when the request does not specify the "collection" param.
- */
-class CloudSolrServers[F[_]](zkHost: String,
-                             zkClientTimeout: Duration = 15 seconds, /* default from Solr Core, see also SOLR-5221*/
-                             zkConnectTimeout: Duration = 10 seconds, /* default from solrj CloudSolrServer*/
-                             clusterStateUpdateInterval: Duration = 1 second,
-                             defaultCollection: Option[String] = None,
-                             warmupQueries: Option[WarmupQueries] = None)
-                            (implicit futureFactory: FutureFactory[F]) extends SolrServers with AsyncSolrClientAware[F] with ServerStateChangeObservable {
+  * Provides servers based on information from from ZooKeeper. Uses the ZkStateReader to read the ZK cluster state,
+  * which is also used by solrj's CloudSolrServer. While ZkStateReader uses ZK Watches to get cluster state changes
+  * from ZK, we're regularly updating our internal state by reading the cluster state from ZkStateReader.
+  *
+  * @param zkHost The zkHost string, in $host:$port format, multiple hosts are specified comma separated
+  * @param zkClientTimeout The zk session timeout (passed to ZkStateReader)
+  * @param zkConnectTimeout The zk connection timeout (passed to ZkStateReader),
+  *                         also used for ZkStateReader initialization attempt interval.
+  *                         Note that we're NOT stopping connection retries after connect timeout!
+  * @param clusterStateUpdateInterval Used for pulling the ClusterState from ZkStateReader
+  * @param defaultCollection Optional default collection to use when the request does not specify the "collection" param.
+  */
+class CloudSolrServers[F[_]](
+    zkHost: String,
+    zkClientTimeout: Duration = 15 seconds, /* default from Solr Core, see also SOLR-5221*/
+    zkConnectTimeout: Duration = 10 seconds, /* default from solrj CloudSolrServer*/
+    clusterStateUpdateInterval: Duration = 1 second,
+    defaultCollection: Option[String] = None,
+    warmupQueries: Option[WarmupQueries] = None)(implicit futureFactory: FutureFactory[F])
+    extends SolrServers
+    with AsyncSolrClientAware[F]
+    with ServerStateChangeObservable {
 
   import CloudSolrServers._
 
@@ -125,11 +130,14 @@ class CloudSolrServers[F[_]](zkHost: String,
 
   @volatile
   private var collections = Map.empty[String, CollectionInfo]
-  private def collectionToServers: Map[String, IndexedSeq[ShardReplica]] = collections.mapValues(_.servers)
+  private def collectionToServers: Map[String, IndexedSeq[ShardReplica]] =
+    collections.toSeq.map(c => (c._1, c._2.servers)).toMap
+
   @volatile
   private var aliases: Option[Aliases] = None
 
-  private val scheduledExecutor: ScheduledExecutorService = Executors.newScheduledThreadPool(1, new ZkClusterStateUpdateTF)
+  private val scheduledExecutor: ScheduledExecutorService =
+    Executors.newScheduledThreadPool(1, new ZkClusterStateUpdateTF)
 
   private var asyncSolrClient: AsyncSolrClient[F] = _
 
@@ -138,18 +146,21 @@ class CloudSolrServers[F[_]](zkHost: String,
     createZkStateReader()
   }
 
-  override protected[solrs] def findLeader(servers: Iterable[SolrServer]): Option[ShardReplica] = ShardReplica.findLeader(servers)
+  override protected[solrs] def findLeader(servers: Iterable[SolrServer]): Option[ShardReplica] =
+    ShardReplica.findLeader(servers)
 
   private def createZkStateReader(): Unit = {
     // Setup ZkStateReader, schedule retry if ZK is unavailable
     try {
       // Creating ZkStateReader can fail when ZK is not available
-      maybeZk = Some(new ZkStateReader(zkHost, zkClientTimeout.toMillis.toInt, zkConnectTimeout.toMillis.toInt))
+      maybeZk = Some(
+        new ZkStateReader(zkHost, zkClientTimeout.toMillis.toInt, zkConnectTimeout.toMillis.toInt))
       logger.info(s"Connected to zookeeper at $zkHost")
       maybeZk.foreach(initZkStateReader)
     } catch {
       case NonFatal(e) =>
-        logger.warn(s"Could not connect to ZK, seems to be unavailable. Retrying in $zkConnectTimeout. Original exception: $e")
+        logger.warn(
+          s"Could not connect to ZK, seems to be unavailable. Retrying in $zkConnectTimeout. Original exception: $e")
         scheduledExecutor.schedule(new Runnable {
           override def run(): Unit = createZkStateReader()
         }, zkConnectTimeout.toMillis, TimeUnit.MILLISECONDS)
@@ -169,8 +180,9 @@ class CloudSolrServers[F[_]](zkHost: String,
       scheduleUpdateFromClusterState(zkStateReader)
     } catch {
       case NonFatal(e) =>
-        logger.warn("Could not initialize ZkStateReader, this can happen when there are no solr servers connected." +
-          s" Retrying in $zkConnectTimeout. Original exception: $e")
+        logger.warn(
+          "Could not initialize ZkStateReader, this can happen when there are no solr servers connected." +
+            s" Retrying in $zkConnectTimeout. Original exception: $e")
         scheduledExecutor.schedule(new Runnable {
           override def run(): Unit = initZkStateReader(zkStateReader)
         }, zkConnectTimeout.toMillis, TimeUnit.MILLISECONDS)
@@ -179,16 +191,20 @@ class CloudSolrServers[F[_]](zkHost: String,
 
   private def scheduleUpdateFromClusterState(zkStateReader: ZkStateReader): Unit = {
     // reschedule after completion of the previous run, to prevent overlapping updates
-    scheduledExecutor.schedule(new Runnable {
-      override def run(): Unit = updateFromClusterState(zkStateReader).onComplete(_ =>
-        scheduleUpdateFromClusterState(zkStateReader)
-      )
-    }, clusterStateUpdateInterval.toMillis, TimeUnit.MILLISECONDS)
+    scheduledExecutor.schedule(
+      new Runnable {
+        override def run(): Unit =
+          updateFromClusterState(zkStateReader).onComplete(_ =>
+            scheduleUpdateFromClusterState(zkStateReader))
+      },
+      clusterStateUpdateInterval.toMillis,
+      TimeUnit.MILLISECONDS
+    )
   }
 
   /**
-   * Updates the server list when the ZkStateReader clusterState changed
-   */
+    * Updates the server list when the ZkStateReader clusterState changed
+    */
   private def updateFromClusterState(zkStateReader: ZkStateReader): Future[Unit] = {
     // could perhaps be replaced with zkStateReader.registerCollectionStateWatcher(collection, watcher);
 
@@ -197,10 +213,11 @@ class CloudSolrServers[F[_]](zkHost: String,
     val clusterState = zkStateReader.getClusterState
 
     def set(newCollections: Map[String, CollectionInfo]): Unit = {
-      notifyObservers(collectionToServers, newCollections.mapValues(_.servers))
+      notifyObservers(collectionToServers, newCollections.toSeq.map(c => (c._1, c._2.servers)).toMap)
       collections = newCollections
-      if (logger.isDebugEnabled) logger.debug (s"Updated server map: $collectionToServers from ClusterState $clusterState")
-      else logger.info (s"Updated server map: $collectionToServers")
+      if (logger.isDebugEnabled)
+        logger.debug(s"Updated server map: $collectionToServers from ClusterState $clusterState")
+      else logger.info(s"Updated server map: $collectionToServers")
     }
 
     try {
@@ -208,45 +225,53 @@ class CloudSolrServers[F[_]](zkHost: String,
 
       if (newCollections != collections) warmupQueries match {
         case Some(warmup) =>
-          warmupNewServers(newCollections.mapValues(_.servers), warmup)
-          .map(_ => set(newCollections))
+          warmUpNewServers(newCollections.toSeq.map(c => (c._1, c._2.servers)).toMap, warmup)
+            .map(_ => set(newCollections))
         case None =>
           futureFactory.successful(set(newCollections))
       } else futureFactory.successful(())
 
     } catch {
       case NonFatal(e) =>
-        logger.error(s"Could not process cluster state, server list might get outdated. Cluster state: $clusterState", e)
+        logger.error(
+          s"Could not process cluster state, server list might get outdated. Cluster state: $clusterState",
+          e)
         futureFactory.failed(e)
     }
   }
 
-  protected def warmupNewServers(newCollectionToServers: Map[String, IndexedSeq[SolrServer]],
-                               warmup: WarmupQueries): Future[Iterable[Try[QueryResponse]]] = {
+  protected def warmUpNewServers(newCollectionToServers: Map[String, IndexedSeq[SolrServer]],
+                                 warmUp: WarmupQueries): Future[Iterable[Try[QueryResponse]]] = {
 
-    val perCollectionResponses = newCollectionToServers.flatMap { case (collection, solrServers) =>
-      val existingServers = collectionToServers.getOrElse(collection, IndexedSeq.empty)
-      // SolrServer.equals checks both baseUrl and status, therefore we can just use contains
-      val newActiveServers = solrServers.filter(s => s.isEnabled && !existingServers.contains(s))
-      newActiveServers.map(warmupNewServer(collection, _, warmup.queriesByCollection(collection), warmup.count))
+    val perCollectionResponses = newCollectionToServers.toSeq.flatMap {
+      case (collection: String, solrServers: IndexedSeq[SolrServer]) =>
+        val existingServers = collectionToServers.getOrElse(collection, IndexedSeq.empty)
+        // SolrServer.equals checks both baseUrl and status, therefore we can just use contains
+        val newActiveServers = solrServers.filter(s => s.isEnabled && !existingServers.contains(s))
+        newActiveServers.map(
+          warmupNewServer(collection, _, warmUp.queriesByCollection(collection), warmUp.count))
     }
 
     FutureFactory.sequence(perCollectionResponses).map(_.flatten)
   }
 
-  protected def warmupNewServer(collection: String, s: SolrServer, queries: Seq[SolrQuery], count: Int): Future[Seq[Try[QueryResponse]]] = {
+  protected def warmupNewServer(collection: String,
+                                s: SolrServer,
+                                queries: Seq[SolrQuery],
+                                count: Int): Future[Seq[Try[QueryResponse]]] = {
     // queries shall be run in parallel, one round after the other
     (1 to count).foldLeft(futureFactory.successful(Seq.empty[Try[QueryResponse]])) { (res, round) =>
       res.flatMap { _ =>
-        val warmupResponses = queries.map(q =>
-          asyncSolrClient.doExecute[QueryResponse](s, new QueryRequest(q))
-            .map(Success(_))
-            .handle {
-            case NonFatal(e) =>
-              logger.warn(s"Warmup query $q failed", e)
-              Failure(e)
-          }
-        )
+        val warmupResponses = queries.map(
+          q =>
+            asyncSolrClient
+              .doExecute[QueryResponse](s, new QueryRequest(q))
+              .map(Success(_))
+              .handle {
+                case NonFatal(e) =>
+                  logger.warn(s"Warmup query $q failed", e)
+                  Failure(e)
+            })
         FutureFactory.sequence(warmupResponses)
       }
     }
@@ -259,21 +284,23 @@ class CloudSolrServers[F[_]](zkHost: String,
   }
 
   /**
-   * The currently known solr servers.
-   */
+    * The currently known solr servers.
+    */
   @volatile
-  override def all: IndexedSeq[SolrServer] = collections.values.flatMap(_.servers)(breakOut)
+  override def all: IndexedSeq[SolrServer] = collections.values.flatMap(_.servers).toIndexedSeq
 
   /**
-   * An infinite iterator over known solr servers. When the last item is reached,
-   * it should start from the first one again. When the known solr servers change,
-   * the iterator must reflect this.
-   */
+    * An infinite iterator over known solr servers. When the last item is reached,
+    * it should start from the first one again. When the known solr servers change,
+    * the iterator must reflect this.
+    */
   override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = {
     val params = r.getParams
+
     val collection = Option(params.get("collection")).orElse(defaultCollection).map(_.split(",")(0)).getOrElse(
       throw new SolrServerException("No collection param specified on request and no default collection has been set.")
     )
+
     // - resolveAliases returns the input if no alias exists
     // - update requests shall only be directed to a single collection (the first of multiple alias target collections, as done by CloudSolrClient)
     // - for read requests we also only consider the first alias target, to keep things simple, and solr server
@@ -283,9 +310,8 @@ class CloudSolrServers[F[_]](zkHost: String,
       case Some(CollectionInfo(docCollection, servers)) =>
         val shardKeys = params.get(ShardParams._ROUTE_)
         val slices = docCollection.getRouter.getSearchSlices(shardKeys, params, docCollection)
-        val serverUrls: Set[String] = mapSliceReplicas(slices)(repl =>
-          SolrServer.fixUrl(repl.getCoreUrl)
-        )(breakOut)
+        val serverUrls: Set[String] =
+          mapSliceReplicas(slices)(repl => SolrServer.fixUrl(repl.getCoreUrl)).toSet
         Success(servers.filter(server => serverUrls.contains(server.baseUrl)))
       case None =>
         Failure(UnknownCollectionException(collection))
@@ -300,7 +326,8 @@ class CloudSolrServers[F[_]](zkHost: String,
     serverChangeStateObservers += listener
   }
 
-  private def notifyObservers(oldState: Map[String, Seq[SolrServer]], newState: Map[String, Seq[SolrServer]]): Unit = {
+  private def notifyObservers(oldState: Map[String, Seq[SolrServer]],
+                              newState: Map[String, Seq[SolrServer]]): Unit = {
     CloudSolrServers.diff(oldState, newState).foreach { event =>
       serverChangeStateObservers.foreach(_.onStateChange(event))
     }
@@ -312,24 +339,31 @@ object CloudSolrServers {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  final case class UnknownCollectionException(collection: String) extends IllegalArgumentException(
-    s"The collection '$collection' is not known"
-  )
+  final case class UnknownCollectionException(collection: String)
+      extends IllegalArgumentException(
+        s"The collection '$collection' is not known"
+      )
 
   /* Java API */
-  case class Builder(zkHost: String,
-                     zkClientTimeout: Duration = 15 seconds, /* default from Solr Core, see also SOLR-5221*/
-                     zkConnectTimeout: Duration = 10 seconds, /* default from solrj CloudSolrServer*/
-                     clusterStateUpdateInterval: Duration = 1 second,
-                     defaultCollection: Option[String] = None,
-                     warmupQueries: Option[WarmupQueries] = None) {
-    def withZkClientTimeout(value: Long, unit: TimeUnit): Builder = copy(zkClientTimeout = FiniteDuration(value, unit))
-    def withZkConnectTimeout(value: Long, unit: TimeUnit): Builder = copy(zkConnectTimeout = FiniteDuration(value, unit))
-    def withClusterStateUpdateInterval(value: Long, unit: TimeUnit): Builder = copy(clusterStateUpdateInterval = FiniteDuration(value, unit))
-    def withDefaultCollection(collection: String): Builder = copy(defaultCollection = Some(collection))
+  case class Builder(
+      zkHost: String,
+      zkClientTimeout: Duration = 15 seconds, /* default from Solr Core, see also SOLR-5221*/
+      zkConnectTimeout: Duration = 10 seconds, /* default from solrj CloudSolrServer*/
+      clusterStateUpdateInterval: Duration = 1 second,
+      defaultCollection: Option[String] = None,
+      warmupQueries: Option[WarmupQueries] = None) {
+    def withZkClientTimeout(value: Long, unit: TimeUnit): Builder =
+      copy(zkClientTimeout = FiniteDuration(value, unit))
+    def withZkConnectTimeout(value: Long, unit: TimeUnit): Builder =
+      copy(zkConnectTimeout = FiniteDuration(value, unit))
+    def withClusterStateUpdateInterval(value: Long, unit: TimeUnit): Builder =
+      copy(clusterStateUpdateInterval = FiniteDuration(value, unit))
+    def withDefaultCollection(collection: String): Builder =
+      copy(defaultCollection = Some(collection))
     import java.lang.{Iterable => JIterable}
     import java.util.function.{Function => JFunction}
-    def withWarmupQueries(queriesByCollection: JFunction[String, JIterable[SolrQuery]], count: Int): Builder = {
+    def withWarmupQueries(queriesByCollection: JFunction[String, JIterable[SolrQuery]],
+                          count: Int): Builder = {
       def delegate(collection: String): Seq[SolrQuery] = {
         val res = queriesByCollection(collection)
         import scala.collection.JavaConverters._
@@ -338,76 +372,95 @@ object CloudSolrServers {
       copy(warmupQueries = Some(WarmupQueries(delegate, count)))
     }
 
-    def build(): CloudSolrServers[CompletionStage] = new CloudSolrServers(zkHost, zkConnectTimeout, zkConnectTimeout, clusterStateUpdateInterval, defaultCollection, warmupQueries)(JavaFutureFactory)
+    def build(): CloudSolrServers[CompletionStage] =
+      new CloudSolrServers(zkHost,
+                           zkConnectTimeout,
+                           zkConnectTimeout,
+                           clusterStateUpdateInterval,
+                           defaultCollection,
+                           warmupQueries)(JavaFutureFactory)
 
     def build[F[_]](implicit futureFactory: FutureFactory[F]): CloudSolrServers[F] =
-      new CloudSolrServers(zkHost, zkConnectTimeout, zkConnectTimeout, clusterStateUpdateInterval, defaultCollection, warmupQueries)
+      new CloudSolrServers(zkHost,
+                           zkConnectTimeout,
+                           zkConnectTimeout,
+                           clusterStateUpdateInterval,
+                           defaultCollection,
+                           warmupQueries)
   }
 
   /* Java API */
   def builder(zkHost: String): Builder = Builder(zkHost)
 
-  private[CloudSolrServers] final case class CollectionInfo(collection: DocCollection, servers: IndexedSeq[ShardReplica])
+  private[CloudSolrServers] final case class CollectionInfo(collection: DocCollection,
+                                                            servers: IndexedSeq[ShardReplica])
 
   private[solrs] def getCollections(clusterState: ClusterState): Map[String, CollectionInfo] = {
     import scala.collection.JavaConverters._
 
     clusterState.getCollectionsMap.asScala.foldLeft(
       Map.empty[String, CollectionInfo]
-    ) { case (res, (name, collection)) =>
-      val servers = mapSliceReplicas(collection.getSlices)(repl => ShardReplica(repl.getCoreUrl, repl))(breakOut)
-      res.updated(name, CollectionInfo(collection, servers))
+    ) {
+      case (res, (name, collection)) =>
+        val servers = mapSliceReplicas(collection.getSlices)(repl => ShardReplica(repl.getCoreUrl, repl)).toIndexedSeq
+        res.updated(name, CollectionInfo(collection, servers))
     }
   }
 
-  private def mapSliceReplicas[A, T <: Iterable[A]](slices: util.Collection[Slice])
-                                                   (fun: Replica => A)
-                                                   (implicit cbf: CanBuildFrom[Iterable[Slice], A, T]): T = {
+  private def mapSliceReplicas[A](slices: util.Collection[Slice])(fun: Replica => A): Iterable[A] = {
     import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-    slices.asScala.flatMap(_.getReplicas.asScala.map(repl =>
-      fun(repl)
-    ))(breakOut)
+    slices.asScala.flatMap(_.getReplicas.asScala.map(repl => fun(repl)))
   }
 
   /**
-   * Specifies how newly added servers / servers that changed from down to active are put under load.
-   * @param queriesByCollection a function that returns warmup queries for a given collection.
-   * @param count the number of times that the queries shall be run.s
-   */
+    * Specifies how newly added servers / servers that changed from down to active are put under load.
+    *
+    * @param queriesByCollection a function that returns warmup queries for a given collection.
+    * @param count the number of times that the queries shall be run.s
+    */
   case class WarmupQueries(queriesByCollection: String => Seq[SolrQuery], count: Int)
 
-  private[solrs] def diff(oldState: Map[String, Seq[SolrServer]], newState: Map[String, Seq[SolrServer]]): Iterable[StateChange] = {
+  private[solrs] def diff(oldState: Map[String, Seq[SolrServer]],
+                          newState: Map[String, Seq[SolrServer]]): Iterable[StateChange] = {
 
     import ServerStateChangeObservable._
 
-    def changes(servers1: Seq[SolrServer], servers2: Seq[SolrServer],
+    def changes(servers1: Seq[SolrServer],
+                servers2: Seq[SolrServer],
                 stateChanged: (SolrServer, SolrServer) => StateChanged,
                 onlyInServers2: SolrServer => StateChange): Set[StateChange] = {
       servers2.foldLeft(Set.empty[StateChange]) { (res, server2) =>
         servers1.find(_.baseUrl == server2.baseUrl) match {
           case Some(server1) if server1 == server2 => res
-          case Some(server1) => res + stateChanged(server1, server2)
-          case None => res + onlyInServers2(server2)
+          case Some(server1)                       => res + stateChanged(server1, server2)
+          case None                                => res + onlyInServers2(server2)
         }
       }
     }
 
-    val changesFromOldCollections = oldState.flatMap { case (collection, oldServers) =>
-      val newServers = newState.getOrElse(collection, Nil)
-      val changesFromOldState = changes(oldServers, newServers,
-        stateChanged = (oldServer, newServer) => StateChanged(oldServer, newServer, collection),
-        onlyInServers2 = server2 => Added(server2, collection))
-      val changesFromNewState = changes(newServers, oldServers,
-        stateChanged = (newServer, oldServer) => StateChanged(oldServer, newServer, collection),
-        onlyInServers2 = server2 => Removed(server2, collection))
-      changesFromOldState ++ changesFromNewState
+    val changesFromOldCollections = oldState.flatMap {
+      case (collection : String, oldServers: Seq[SolrServer]) =>
+        val newServers = newState.getOrElse(collection, Nil)
+        val changesFromOldState = changes(
+          oldServers,
+          newServers,
+          stateChanged = (oldServer, newServer) => StateChanged(oldServer, newServer, collection),
+          onlyInServers2 = server2 => Added(server2, collection)
+        )
+        val changesFromNewState = changes(
+          newServers,
+          oldServers,
+          stateChanged = (newServer, oldServer) => StateChanged(oldServer, newServer, collection),
+          onlyInServers2 = server2 => Removed(server2, collection)
+        )
+        changesFromOldState ++ changesFromNewState
     }
 
     val changesFromNewCollections = newState
-      .filterKeys(newCollection => !oldState.contains(newCollection))
+      .toSeq
+      .filter(newCollection => !oldState.contains(newCollection._1))
       .flatMap {
-        case (collection, newServers) =>
-          newServers.map(Added(_, collection))
+        case (collection: String, newServers: Seq[SolrServer]) => newServers.map(Added(_, collection))
       }
 
     changesFromOldCollections ++ changesFromNewCollections
@@ -415,23 +468,26 @@ object CloudSolrServers {
 
 }
 
-class ReloadingSolrServers[F[_]](url: String, extractor: Array[Byte] => IndexedSeq[SolrServer], httpClient: AsyncHttpClient)
-                                (implicit futureFactory: FutureFactory[F] = ScalaFutureFactory) extends SolrServers {
+class ReloadingSolrServers[F[_]](
+    url: String,
+    extractor: Array[Byte] => IndexedSeq[SolrServer],
+    httpClient: AsyncHttpClient)(implicit futureFactory: FutureFactory[F])
+    extends SolrServers {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   private var solrServers = IndexedSeq.empty[SolrServer]
 
   /**
-   * The currently known solr servers.
-   */
+    * The currently known solr servers.
+    */
   override def all: IndexedSeq[SolrServer] = solrServers
 
   /**
-   * An infinite iterator over known solr servers. When the last item is reached,
-   * it should start from the first one again. When the known solr servers change,
-   * the iterator must reflect this.
-   */
+    * An infinite iterator over known solr servers. When the last item is reached,
+    * it should start from the first one again. When the known solr servers change,
+    * the iterator must reflect this.
+    */
   override def matching(r: SolrRequest[_]): Try[IndexedSeq[SolrServer]] = Success(solrServers)
 
   def reload(): F[IndexedSeq[SolrServer]] = {
@@ -448,18 +504,19 @@ class ReloadingSolrServers[F[_]](url: String, extractor: Array[Byte] => IndexedS
 
   protected def loadUrl(): Future[Array[Byte]] = {
     val promise = futureFactory.newPromise[Array[Byte]]
-    httpClient.prepareGet(url).execute(new AsyncCompletionHandler[Response]() {
-      override def onCompleted(response: Response): Response = {
-        promise.success(response.getResponseBodyAsBytes)
-        response
-      }
-      override def onThrowable(t: Throwable) {
-        logger.error("Could not load solr server list.", t)
-        promise.failure(t)
-      }
-    })
+    httpClient
+      .prepareGet(url)
+      .execute(new AsyncCompletionHandler[Response]() {
+        override def onCompleted(response: Response): Response = {
+          promise.success(response.getResponseBodyAsBytes)
+          response
+        }
+        override def onThrowable(t: Throwable): Unit = {
+          logger.error("Could not load solr server list.", t)
+          promise.failure(t)
+        }
+      })
     promise.future
   }
-
 
 }

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientCloudIntegrationSpec.scala
@@ -43,7 +43,7 @@ class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventuall
 
   import io.ino.solrs.SolrUtils._
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     solrRunner = SolrCloudRunner.start(
       numServers = 2,
       collections = List(
@@ -80,7 +80,7 @@ class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventuall
     }
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     solrJClient.close()
     cut.shutdown()
     solrServers.shutdown()
@@ -162,8 +162,8 @@ class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventuall
       awaitAllServersBeingEnabled()
 
       val otherDocs = manyDocs.filterNot(someDocs.contains).take(42)
-      import scala.collection.JavaConverters.seqAsJavaListConverter
-      solrJClient.add(collection2, otherDocs.asJava)
+      import scala.jdk.CollectionConverters._
+      solrJClient.add(collection2, otherDocs.asJavaCollection)
       solrJClient.commit(collection2)
 
       val alias = "testalias"
@@ -201,8 +201,10 @@ class AsyncSolrClientCloudIntegrationSpec extends StandardFunSpec with Eventuall
       awaitAllServersBeingEnabled()
 
       val otherDocs = manyDocs.filterNot(someDocs.contains).take(42)
-      import scala.collection.JavaConverters.seqAsJavaListConverter
-      solrJClient.add(collection2, otherDocs.asJava)
+
+      import scala.jdk.CollectionConverters._
+      solrJClient.add(collection2, otherDocs.asJavaCollection)
+
       solrJClient.commit(collection2)
       val otherDocsIds = otherDocs.map(_.getFieldValue("id").toString)
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -20,7 +20,7 @@ class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
 
   import io.ino.solrs.SolrUtils._
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     eventually(Timeout(10 seconds)) {
       solrJClient.deleteByQuery("*:*")
     }

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -40,7 +40,7 @@ class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
 
   import io.ino.solrs.SolrUtils._
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     eventually(Timeout(10 seconds)) {
       solrJClient.deleteByQuery("*:*")
     }

--- a/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
@@ -24,7 +24,7 @@ class CloudSolrServersUninitializedIntegrationSpec extends StandardFunSpec {
 
   private type AsyncSolrClient = io.ino.solrs.AsyncSolrClient[Future]
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     cut.foreach(_.shutdown())
     cut = None
 

--- a/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/FastestServerLBSpec.scala
@@ -370,8 +370,8 @@ class FastestServerLBSpec extends StandardFunSpec {
                            mapPredictedResponseTime: Long => Long = identity): FastestServerLB = {
     cut = new FastestServerLB(solrServers, _ => ("collection1", q), minDelay, maxDelay = 30 seconds, initialTestRuns = 1,
       mapPredictedResponseTime = mapPredictedResponseTime, clock = clock) {
-      override protected def scheduleTests(): Unit = Unit
-      override protected def scheduleUpdateStats(): Unit = Unit
+      override protected def scheduleTests(): Unit = ()
+      override protected def scheduleUpdateStats(): Unit = ()
     }
     cut.setAsyncSolrClient(solrs)
     cut

--- a/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
@@ -39,7 +39,7 @@ class PingStatusObserverIntegrationSpec extends FunSpec with BeforeAndAfterAll w
     solrRunner.stop()
   }
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     responseDelayMillis.set(0)
     doReturn404.set(false)
     eventually {
@@ -47,7 +47,7 @@ class PingStatusObserverIntegrationSpec extends FunSpec with BeforeAndAfterAll w
     }
   }
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     if (solrRunner.jetty.isStopped) {
       solrRunner.jetty.start()
     }

--- a/src/test/scala/io/ino/solrs/RunningSolr.scala
+++ b/src/test/scala/io/ino/solrs/RunningSolr.scala
@@ -9,13 +9,13 @@ trait RunningSolr extends BeforeAndAfterAll {
   protected var solrRunner: SolrRunner = _
   protected var solrJClient: HttpSolrClient = _
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     solrRunner = SolrRunner.startOnce(8888)
 
     solrJClient = new HttpSolrClient.Builder("http://localhost:" + solrRunner.port + "/solr/collection1").build()
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     solrJClient.close()
   }
 

--- a/src/test/scala/io/ino/solrs/SolrCloudRunner.scala
+++ b/src/test/scala/io/ino/solrs/SolrCloudRunner.scala
@@ -57,7 +57,7 @@ class SolrCloudRunner(numServers: Int, collections: List[SolrCollection] = List.
 
   // shutdown hook clean up for tests that don't call shutdown explicitly
   Runtime.getRuntime.addShutdownHook(new Thread() {
-    override def run() {
+    override def run(): Unit = {
       shutdown()
     }
   })

--- a/src/test/scala/io/ino/solrs/SolrRunner.scala
+++ b/src/test/scala/io/ino/solrs/SolrRunner.scala
@@ -82,7 +82,7 @@ class SolrRunner(val port: Int,
 
   def isStarted: Boolean = jetty != null && jetty.isRunning
 
-  def stop() {
+  def stop(): Unit = {
     if(isStarted) {
       logger.info(s"Stopping Solr Jetty running on port $port")
       SolrRunner.stopJetty(jetty)
@@ -147,7 +147,7 @@ object SolrRunner {
       solrRunners += port -> solrRunner
 
       Runtime.getRuntime.addShutdownHook(new Thread() {
-        override def run() {
+        override def run(): Unit = {
           solrRunner.stop()
         }
       })

--- a/src/test/scala/io/ino/solrs/SolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/SolrServersSpec.scala
@@ -32,6 +32,8 @@ class SolrServersSpec extends FunSpec with Matchers with FutureAwaits {
 
       var data = "host1,host2"
 
+      import io.ino.solrs.future.ScalaFutureFactory.Implicit
+
       val cut = new ReloadingSolrServers[Future]("http://some.url", parse, null) {
         override def loadUrl() = {
           val promise = io.ino.solrs.future.ScalaFutureFactory.newPromise[Array[Byte]]


### PR DESCRIPTION
## Changelog
- Added support for Scala 2.13
- Support for Scala 2.11 has been removed

## Questions / ToDo
- Still using old `scala.collections.JavaConverters` methods.
  - Unit tests have been changed to use `scala.jdk.CollectionConverters`, though