### PR TITLE
Fix travis yaml deploy condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    condition: ! grep SNAPSHOT version.sbt && $TRAVIS_PULL_REQUEST = false && $TRAVIS_SCALA_VERSION = 2.12*
+    condition: $(! grep SNAPSHOT version.sbt && [[ $TRAVIS_PULL_REQUEST = false ]] && [[ $TRAVIS_SCALA_VERSION = 2.12* ]])
 
 cache:
   directories:


### PR DESCRIPTION
The site was not deployed, and builds contained errors like this:
```
/home/travis/.travis/job_stages: line 827: conditional binary operator expected
7/home/travis/.travis/job_stages: line 827: expected `)'
8/home/travis/.travis/job_stages: line 827: syntax error near `SNAPSHOT'
9/home/travis/.travis/job_stages: line 827: `  if [[ ($TRAVIS_BRANCH = master) && (grep SNAPSHOT version.sbt && $TRAVIS_PULL_REQUEST = false && $TRAVIS_SCALA_VERSION = 2.12*) ]]; then'
```