### PR TITLE
Bumping AsyncHttpClient to 2.12.1, slf4j to 1.7.30

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,11 +39,11 @@ resolvers ++= Seq(
 )
 
 val solrVersion = "7.7.2"
-val slf4jVersion = "1.7.29"
+val slf4jVersion = "1.7.30"
 
 libraryDependencies ++= Seq(
   "org.apache.solr"         % "solr-solrj"        % solrVersion,
-  "org.asynchttpclient"     % "async-http-client" % "2.10.5",
+  "org.asynchttpclient"     % "async-http-client" % "2.12.1",
   "org.scala-lang.modules" %% "scala-xml"         % "1.2.0",
   "org.scala-lang.modules" %% "scala-java8-compat"% "0.9.0",
   "io.dropwizard.metrics"   % "metrics-core"      % "3.2.6" % "optional",


### PR DESCRIPTION
AsyncHttpClient releases came in quick succession, at a first glance they were mostly concerned with library updates and contain no breaking changes