### PR TITLE
Add scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,10 @@ scmInfo := Some(ScmInfo(url("https://github.com/inoio/solrs"), "git@github.com:i
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
-scalaVersion := "2.12.17"
+scalaVersion := "3.2.1"
 
 // Remember: also update scala versions in .travis.yml!
-crossScalaVersions := Seq("2.12.17", "2.13.10")
+crossScalaVersions := Seq("2.12.17", "2.13.10", "3.2.1")
 
 scalacOptions ++= Seq(
   "-unchecked",
@@ -56,8 +56,14 @@ libraryDependencies ++= Seq(
   "org.scalatestplus"      %% "junit-4-13"        % "3.2.14.0" % "test",
   "com.github.sbt"          % "junit-interface"   % "0.13.3" % Test,
   "org.hamcrest"            % "hamcrest-library"  % "2.2" % "test",
+  "dev.zio"                %% "izumi-reflect"     % "2.2.3" % Test,
   "org.apache.solr"         % "solr-test-framework" % solrVersion % "test" excludeAll(ExclusionRule(organization = "org.apache.logging.log4j")),
   "com.twitter"            %% "util-core"         % "22.12.0" % "optional"
+)
+
+excludeDependencies ++= (
+  if (scalaVersion.value.startsWith("2.12")) Seq()
+  else Seq("org.scala-lang.modules" %% "scala-collection-compat")
 )
 
 // Fork tests so that SolrRunner's shutdown hook kicks in

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -45,7 +45,7 @@ You must add the library to the dependencies of the build file:
   version="$project.version$"
 }
 
-solrs is published to maven central for scala 2.11 (up to version 2.3.0), 2.12 and 2.13.
+solrs is published to maven central for scala 2.11 (up to version 2.3.0), 2.12, 2.13 and 3.2 (since version 2.6.2).
 
 ## License
 

--- a/src/main/paradox/resources/HelloScala.scala
+++ b/src/main/paradox/resources/HelloScala.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class HelloScala extends App {
 
-  val solr = AsyncSolrClient("http://localhost:8983/solr/collection1")
+  val solr: AsyncSolrClient[Future] = AsyncSolrClient("http://localhost:8983/solr/collection1")
   val response: Future[QueryResponse] = solr.query(new SolrQuery("scala"))
   response.foreach {
     qr => println(s"found ${qr.getResults.getNumFound} docs")

--- a/src/main/paradox/resources/HelloTwitter.scala
+++ b/src/main/paradox/resources/HelloTwitter.scala
@@ -6,7 +6,7 @@ import com.twitter.util.Future
 
 class HelloTwitter extends App {
 
-  val solr = AsyncSolrClient("http://localhost:8983/solr")
+  val solr: AsyncSolrClient[Future] = AsyncSolrClient("http://localhost:8983/solr")
   val response: Future[QueryResponse] = solr.query(new SolrQuery("scala"))
   response.onSuccess {
     qr => println(s"found ${qr.getResults.getNumFound} docs")

--- a/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/AsyncSolrClient.scala
@@ -51,7 +51,7 @@ import org.asynchttpclient.Response
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal

--- a/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
+++ b/src/main/scala/io/ino/solrs/JavaAsyncSolrClient.scala
@@ -21,7 +21,7 @@ import org.apache.solr.common.SolrDocumentList
 import org.apache.solr.common.SolrInputDocument
 import org.asynchttpclient.AsyncHttpClient
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FunctionConverters._
 import scala.compat.java8.OptionConverters._
 

--- a/src/main/scala/io/ino/solrs/LoadBalancer.scala
+++ b/src/main/scala/io/ino/solrs/LoadBalancer.scala
@@ -102,7 +102,7 @@ object RoundRobinLB {
   def apply(baseUrls: IndexedSeq[String]): RoundRobinLB = new RoundRobinLB(StaticSolrServers(baseUrls))
 
   /* Java API */
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   def create(baseUrls: java.lang.Iterable[String]): RoundRobinLB = apply(baseUrls.asScala.toIndexedSeq)
 }
 
@@ -502,7 +502,7 @@ import java.lang.management.ManagementFactory
 import javax.management.ObjectName
 import javax.management.openmbean._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * JMX support for FastestServerLB, implementation of FastestServerLBMBean, to be mixed into FastestServerLB.

--- a/src/main/scala/io/ino/solrs/PerformanceStats.scala
+++ b/src/main/scala/io/ino/solrs/PerformanceStats.scala
@@ -88,7 +88,7 @@ class PerformanceStats(val solrServer: SolrServer, initialPredictedResponseTime:
     // those requests will no longer be available for prediction
     currentRequests.values.foreach { requests =>
       if(requests.size() > currentRequestsSizeCheckLimit) {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val requestsToRemove = requests.asScala.filter(_.startedAtMillis > currentRequestsRemoveThreshold)
         logger.warn(s"Current requests exceed limit $currentRequestsSizeCheckLimit, removing ${requestsToRemove.size} requests for cleanup.")
         requestsToRemove.foreach(entry => requests.remove(entry))
@@ -145,7 +145,7 @@ class PerformanceStats(val solrServer: SolrServer, initialPredictedResponseTime:
   def dumpStats(queryClass: QueryClass): Unit = {
     val sb = new StringBuilder()
     sb.append(s"====== stats for [${solrServer.baseUrl}][queryClass $queryClass] at ${clock.millis()} millis ======")
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     currentRequests(queryClass).asScala.foreach(req => sb.append(s"\n[currentRequest] $req"))
     buckets.foreach { case (sec, bucket) =>
       bucket.averageDuration(queryClass).foreach(duration => sb.append(s"\n[bucket(sec $sec)] $duration"))

--- a/src/main/scala/io/ino/solrs/RetryPolicy.scala
+++ b/src/main/scala/io/ino/solrs/RetryPolicy.scala
@@ -36,8 +36,8 @@ case class RetryServer(server: SolrServer) extends RetryDecision {
 
 object RetryDecision {
 
-  final val Fail = StandardRetryDecision(Result.Fail)
-  final val Retry = StandardRetryDecision(Result.Retry)
+  final val Fail: StandardRetryDecision = StandardRetryDecision(Result.Fail)
+  final val Retry: StandardRetryDecision = StandardRetryDecision(Result.Retry)
 
   sealed trait Result
   object Result {

--- a/src/main/scala/io/ino/solrs/SolrServers.scala
+++ b/src/main/scala/io/ino/solrs/SolrServers.scala
@@ -11,7 +11,6 @@ import io.ino.solrs.ServerStateChangeObservable.StateChange
 import io.ino.solrs.future.Future
 import io.ino.solrs.future.FutureFactory
 import io.ino.solrs.future.JavaFutureFactory
-import io.ino.solrs.future.ScalaFutureFactory
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.SolrRequest
 import org.apache.solr.client.solrj.SolrServerException
@@ -24,7 +23,6 @@ import org.asynchttpclient.AsyncHttpClient
 import org.asynchttpclient.Response
 import org.slf4j.LoggerFactory
 
-import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import scala.util.Failure
 import scala.util.Success
@@ -61,7 +59,7 @@ object StaticSolrServers {
     new StaticSolrServers(baseUrls.map(SolrServer(_)))
 
   /* Java API */
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
   def create(baseUrls: java.lang.Iterable[String]): StaticSolrServers =
     apply(baseUrls.asScala.toIndexedSeq)
 }
@@ -366,7 +364,7 @@ object CloudSolrServers {
                           count: Int): Builder = {
       def delegate(collection: String): Seq[SolrQuery] = {
         val res = queriesByCollection(collection)
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         res.asScala.toList
       }
       copy(warmupQueries = Some(WarmupQueries(delegate, count)))
@@ -396,7 +394,7 @@ object CloudSolrServers {
                                                             servers: IndexedSeq[ShardReplica])
 
   private[solrs] def getCollections(clusterState: ClusterState): Map[String, CollectionInfo] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     clusterState.getCollectionsMap.asScala.foldLeft(
       Map.empty[String, CollectionInfo]
@@ -408,7 +406,7 @@ object CloudSolrServers {
   }
 
   private def mapSliceReplicas[A](slices: util.Collection[Slice])(fun: Replica => A): Iterable[A] = {
-    import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+    import scala.jdk.CollectionConverters._
     slices.asScala.flatMap(_.getReplicas.asScala.map(repl => fun(repl)))
   }
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -8,7 +8,6 @@ import org.apache.solr.client.solrj.beans.Field
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
-import scala.annotation.meta.field
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
@@ -202,9 +201,48 @@ class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
 
 }
 
+/*
 case class TestBean(@(Field @field) id: String,
                     @(Field @field) name: String,
                     @(Field @field) category: String,
                     @(Field @field) price: Float) {
   def this() = this(null, null, null, 0)
+}
+*/
+
+/* Can be replaced by the version above, once
+  https://github.com/lampepfl/dotty/issues/12492 respectively https://github.com/lampepfl/dotty/pull/16445
+  are released (see https://github.com/lampepfl/dotty/releases)
+ */
+class TestBean(_id: String, _name: String, _category: String, _price: Float) {
+  def this() = this(null, null, null, 0)
+
+  @Field
+  val id: String = _id
+  @Field
+  val name: String = _name
+  @Field
+  val category: String = _category
+  @Field
+  val price: Float = _price
+
+  override def equals(other: Any): Boolean = other match {
+    case that: TestBean =>
+      id == that.id &&
+        name == that.name &&
+        category == that.category &&
+        price == that.price
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(id, name, category, price)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+}
+
+object TestBean {
+  def apply(id: String, name: String, category: String, price: Float): TestBean =
+    new TestBean(_id = id, _name = name, _category = category, _price = price)
 }

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientFunSpec.scala
@@ -9,12 +9,12 @@ import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.annotation.meta.field
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 class AsyncSolrClientFunSpec extends StandardFunSpec with RunningSolr {
 
-  private implicit val timeout = 1.second
+  private implicit val timeout: FiniteDuration = 1.second
 
   private lazy val solrs = AsyncSolrClient(s"http://localhost:${solrRunner.port}/solr/collection1")
 

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientIntegrationSpec.scala
@@ -27,12 +27,12 @@ import scala.xml.XML
 
 class AsyncSolrClientIntegrationSpec extends StandardFunSpec with RunningSolr {
 
-  private implicit val patienceConfig = PatienceConfig(
+  private implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout = scaled(Span(10000, Millis)),
     interval = scaled(Span(20, Millis))
   )
 
-  private implicit val timeout = 1.second
+  private implicit val timeout: FiniteDuration = 1.second
   private val httpClient = new DefaultAsyncHttpClient()
 
   private lazy val solrUrl = s"http://localhost:${solrRunner.port}/solr/collection1"

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientSpec.scala
@@ -17,7 +17,7 @@ import scala.util.control.NoStackTrace
 class AsyncSolrClientSpec extends StandardFunSpec {
 
   private val query = new SolrQuery("*:*")
-  private implicit val timeout = 1.second
+  private implicit val timeout: FiniteDuration = 1.second
 
   describe("Solr") {
 

--- a/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersSpec.scala
@@ -44,7 +44,7 @@ class CloudSolrServersSpec extends AnyFunSpec with Matchers {
     }
 
     it("should read all servers from ClusterState with multiple shards") {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
 
       val bytes = Files.readAllBytes(Paths.get(this.getClass.getResource("/cluster_status.json").toURI))
       val cs = ClusterState.load(1, bytes, Set("server1:8983_solr").asJava)

--- a/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/CloudSolrServersUninitializedIntegrationSpec.scala
@@ -14,8 +14,8 @@ import scala.concurrent.duration._
  */
 class CloudSolrServersUninitializedIntegrationSpec extends StandardFunSpec {
 
-  private implicit val awaitTimeout = 2 seconds
-  private implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(1000, Millis)))
+  private implicit val awaitTimeout: FiniteDuration = 2 seconds
+  private implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(1000, Millis)))
 
   private var solrRunner: SolrCloudRunner = _
   private def solrServerUrls = solrRunner.solrCoreUrls

--- a/src/test/scala/io/ino/solrs/Fixtures.scala
+++ b/src/test/scala/io/ino/solrs/Fixtures.scala
@@ -13,7 +13,7 @@ object Fixtures {
       replicaType: Replica.Type = Replica.Type.NRT,
       isLeader: Boolean = false
     ): ShardReplica = {
-    import scala.collection.JavaConverters.mutableMapAsJavaMapConverter
+    import scala.jdk.CollectionConverters._
     val leaderProps: Map[String, AnyRef] = if(isLeader) Map(ZkStateReader.LEADER_PROP -> true.toString) else Map.empty
     val replicaStatus = status match {
       case Enabled => Replica.State.ACTIVE

--- a/src/test/scala/io/ino/solrs/NewMockitoSugar.scala
+++ b/src/test/scala/io/ino/solrs/NewMockitoSugar.scala
@@ -1,8 +1,7 @@
 package io.ino.solrs
 
+import izumi.reflect.Tag
 import org.mockito.Mockito.{mock => mockitoMock}
-
-import scala.reflect.runtime.universe._
 
 /**
  * Improves over MockitoSugar in that it supports higher kinded types.
@@ -11,9 +10,8 @@ import scala.reflect.runtime.universe._
  */
 trait NewMockitoSugar {
 
-  def mock[T <: AnyRef](implicit tag: TypeTag[T]): T = {
-    val m = tag.mirror
-    mockitoMock(m.runtimeClass(tag.tpe).asInstanceOf[Class[T]])
+  def mock[T <: AnyRef](implicit tag: Tag[T]): T = {
+    mockitoMock(tag.closestClass.asInstanceOf[Class[T]])
   }
 
 }

--- a/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/PingStatusObserverIntegrationSpec.scala
@@ -20,7 +20,7 @@ class PingStatusObserverIntegrationSpec extends AnyFunSpec with BeforeAndAfterAl
 
   import PingStatusObserverIntegrationSpec._
 
-  private implicit val awaitTimeout = 2000 millis
+  private implicit val awaitTimeout: FiniteDuration = 2000 millis
   private val httpClientTimeout = 100
   private val httpClient = new DefaultAsyncHttpClient(new DefaultAsyncHttpClientConfig.Builder().setRequestTimeout(httpClientTimeout).build)
 

--- a/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
+++ b/src/test/scala/io/ino/solrs/RoundRobinLBSpec.scala
@@ -9,12 +9,10 @@ import org.apache.solr.common.cloud.Replica
 import org.apache.solr.common.cloud.Replica.Type.NRT
 import org.apache.solr.common.cloud.Replica.Type.PULL
 import org.apache.solr.common.cloud.Replica.Type.TLOG
-import org.apache.solr.common.params.ShardParams
 import org.apache.solr.common.params.ShardParams.SHARDS_PREFERENCE
 import org.apache.solr.common.params.ShardParams.SHARDS_PREFERENCE_REPLICA_TYPE
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import scala.util.Failure
 import scala.util.Success

--- a/src/test/scala/io/ino/solrs/SolrCloudRunner.scala
+++ b/src/test/scala/io/ino/solrs/SolrCloudRunner.scala
@@ -16,7 +16,7 @@ import org.apache.solr.cloud.ZkTestServer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 // Collection information for SolrCloud
 case class SolrCollection(name: String, replicas: Int = 1, shards: Int = 1)
@@ -137,7 +137,7 @@ class SolrCloudRunner(numServers: Int, collections: List[SolrCollection] = List.
   def solrJClient: CloudSolrClient = miniSolrCloudCluster.getSolrClient
 
   def jettySolrRunners: List[JettySolrRunner] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     miniSolrCloudCluster.getJettySolrRunners.asScala.toList
   }
 

--- a/src/test/scala/io/ino/solrs/SolrRunner.scala
+++ b/src/test/scala/io/ino/solrs/SolrRunner.scala
@@ -28,7 +28,7 @@ class SolrRunner(val port: Int,
 
   import io.ino.solrs.SolrRunner._
 
-  val url = s"http://localhost:$port$context"
+  val url: String = s"http://localhost:$port$context"
   private[solrs] var jetty: JettySolrRunner = _
 
   // init "base" = some temp dir for this run
@@ -38,7 +38,7 @@ class SolrRunner(val port: Int,
   val solrHome: Path = makeSolrHomeDirIn(baseDir)
 
   def start: SolrRunner = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     if (jetty != null) {
       throw new IllegalStateException("Start can only be invoked once. You probably want to use 'stop()' + 'start()'.")

--- a/src/test/scala/io/ino/solrs/SolrServersSpec.scala
+++ b/src/test/scala/io/ino/solrs/SolrServersSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 class SolrServersSpec extends AnyFunSpec with Matchers with FutureAwaits {
 
   private val q = new QueryRequest(new SolrQuery("foo"))
-  private implicit val timeout = 1.second
+  private implicit val timeout: FiniteDuration = 1.second
 
   describe("StaticSolrServers") {
     it("should return consecutive solr servers") {

--- a/src/test/scala/io/ino/solrs/SolrUtils.scala
+++ b/src/test/scala/io/ino/solrs/SolrUtils.scala
@@ -2,7 +2,7 @@ package io.ino.solrs
 
 import java.net.{NetworkInterface, InetAddress}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.solr.client.solrj.response.QueryResponse
 import org.apache.solr.common.SolrInputDocument
@@ -24,7 +24,7 @@ trait SolrUtils {
 
   /** Determines the local hostname as the ZkController does it for SolrCloud nodes.
     */
-  val hostName = {
+  val hostName: String = {
     // See also https://svn.apache.org/repos/asf/lucene/dev/trunk/solr/core/src/java/org/apache/solr/cloud/ZkController.java
     // It picks InetAddress.getLocalHost if != loopback, or the last siteLocalAddress
     if(InetAddress.getLocalHost.getHostAddress != "127.0.0.1") {
@@ -32,7 +32,7 @@ trait SolrUtils {
     }
     else {
       val siteLocalAddresses = for {
-        iface <- NetworkInterface.getNetworkInterfaces().asScala.toList
+        iface <- NetworkInterface.getNetworkInterfaces.asScala.toList
         address <- iface.getInetAddresses.asScala if address.isSiteLocalAddress
       } yield address
       if(siteLocalAddresses.isEmpty) "127.0.0.1" else siteLocalAddresses.last.getHostAddress
@@ -43,12 +43,12 @@ trait SolrUtils {
 
 object SolrUtils extends SolrUtils {
 
-  val manyDocs = (1 to 1000).map(i => newInputDoc(s"id$i", s"doc$i", s"cat${i % 100}", i % 50)).toList
-  val manyDocsIds = manyDocs.map(_.getFieldValue("id").toString)
+  val manyDocs: List[SolrInputDocument] = (1 to 1000).map(i => newInputDoc(s"id$i", s"doc$i", s"cat${i % 100}", i % 50)).toList
+  val manyDocsIds: List[String] = manyDocs.map(_.getFieldValue("id").toString)
   val manyDocsAsJList: java.util.List[SolrInputDocument] = manyDocs.asJava
 
-  val someDocs = manyDocs.take(50)
-  val someDocsIds = someDocs.map(_.getFieldValue("id").toString)
+  val someDocs: List[SolrInputDocument] = manyDocs.take(50)
+  val someDocsIds: List[String] = someDocs.map(_.getFieldValue("id").toString)
   val someDocsAsJList: java.util.List[SolrInputDocument] = someDocs.asJava
 
 }

--- a/src/test/scala/io/ino/solrs/StandardFunSpec.scala
+++ b/src/test/scala/io/ino/solrs/StandardFunSpec.scala
@@ -6,6 +6,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
+import org.apache.solr.client.solrj.ResponseParser
+import org.apache.solr.client.solrj.request.RequestWriter
+import org.asynchttpclient.AsyncHttpClient
 
 /**
  * Default FunSpec mixing in various standard traits, and also ScalaFutureFactory.
@@ -18,8 +21,8 @@ abstract class StandardFunSpec extends AnyFunSpec
   with FutureAwaits
   with NewMockitoSugar {
 
-  protected implicit val futureFactory = ScalaFutureFactory
+  protected implicit val futureFactory: ScalaFutureFactory.type = ScalaFutureFactory
 
-  protected val ascFactory = AsyncSolrClient.ascFactory[Future] _
+  protected val ascFactory: (LoadBalancer, AsyncHttpClient, Boolean, Option[RequestInterceptor], RequestWriter, ResponseParser, Metrics, Option[ServerStateObservation[Future]], RetryPolicy) => AsyncSolrClient[Future] = AsyncSolrClient.ascFactory[Future] _
 
 }

--- a/src/test/scala/io/ino/solrs/usage/UsageScala.scala
+++ b/src/test/scala/io/ino/solrs/usage/UsageScala.scala
@@ -1,6 +1,7 @@
 package io.ino.solrs.usage
 
 import org.slf4j.LoggerFactory
+import scala.concurrent.Future
 
 class UsageScala1 {
 
@@ -58,7 +59,7 @@ class UsageScalaTwitter1 {
   import org.apache.solr.client.solrj.response.QueryResponse
   import com.twitter.util.Future
 
-  val solr = AsyncSolrClient("http://localhost:8983/solr")
+  val solr: AsyncSolrClient[Future] = AsyncSolrClient("http://localhost:8983/solr")
   val response: Future[QueryResponse] = solr.query(new SolrQuery("scala"))
   response.onSuccess {
     qr => println(s"found ${qr.getResults.getNumFound} docs")
@@ -75,7 +76,7 @@ class UsageScala2 {
   import org.apache.solr.client.solrj.impl.XMLResponseParser
   import org.asynchttpclient.DefaultAsyncHttpClient
 
-  val solr = AsyncSolrClient.Builder("http://localhost:8983/solr")
+  val solr: AsyncSolrClient[Future] = AsyncSolrClient.Builder("http://localhost:8983/solr")
     .withHttpClient(new DefaultAsyncHttpClient())
     .withResponseParser(new XMLResponseParser())
     .build

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "2.6.2-SNAPSHOT"
+version := "2.6.2"


### PR DESCRIPTION
Done by using the `sbt-scala3-migrate` plugin, following https://docs.scala-lang.org/scala3/guides/migration/scala3-migrate.html

Closes #105