### PR TITLE
Add `isUpdatesToLeaders` for `RoundRobinLB`/`FastestServerLB` (default `false`)

### DIFF
--- a/src/main/paradox/resources/LoadBalancing.java
+++ b/src/main/paradox/resources/LoadBalancing.java
@@ -16,6 +16,14 @@ class RoundRobin {
   JavaAsyncSolrClient solr = JavaAsyncSolrClient.builder(lb).build();
   // #round_robin
 
+  // #round_robin_update_to_leader
+  RoundRobinLB lb = RoundRobinLB.create(asList(
+          "http://localhost:8983/solr/collection1",
+          "http://localhost:8984/solr/collection1"
+  ), /* isUpdatesToLeaders */ true);
+  JavaAsyncSolrClient solr = JavaAsyncSolrClient.builder(lb).build();
+  // #round_robin_update_to_leader
+
   // #fastest_server
   StaticSolrServers servers = StaticSolrServers.create(Arrays.asList(
     "http://localhost:8983/solr/collection1",
@@ -27,6 +35,7 @@ class RoundRobin {
           .withMinDelay(50, MILLISECONDS)
           .withMaxDelay(5, SECONDS)
           .withInitialTestRuns(50)
+          .withUpdatesToLeaders(true)
           .build();
   JavaAsyncSolrClient solr = JavaAsyncSolrClient.builder(lb).build();
   // #fastest_server

--- a/src/main/paradox/resources/LoadBalancing.scala
+++ b/src/main/paradox/resources/LoadBalancing.scala
@@ -15,6 +15,14 @@ class RoundRobin extends App {
   val solr = AsyncSolrClient.Builder(lb).build
   // #round_robin
 
+  // #round_robin_update_to_leader
+  val lb = RoundRobinLB(IndexedSeq(
+    "http://localhost:8983/solr/collection1",
+    "http://localhost:8984/solr/collection1"
+  ), isUpdatesToLeaders = true)
+  val solr = AsyncSolrClient.Builder(lb).build
+  // #round_robin_update_to_leader
+
   // #fastest_server
   val lb = {
     val servers = StaticSolrServers(IndexedSeq(
@@ -23,7 +31,13 @@ class RoundRobin extends App {
     ))
     val col1TestQuery = "collection1" -> new SolrQuery("*:*").setRows(0)
     def collectionAndTestQuery(server: SolrServer) = col1TestQuery
-    new FastestServerLB(servers, collectionAndTestQuery, minDelay = 50 millis, maxDelay = 5 seconds, initialTestRuns = 50)
+    new FastestServerLB(
+      servers,
+      collectionAndTestQuery,
+      minDelay = 50 millis,
+      maxDelay = 5 seconds,
+      initialTestRuns = 50,
+      isUpdatesToLeaders = true)
   }
   val solr = AsyncSolrClient.Builder(lb).build
   // #fastest_server

--- a/src/main/paradox/usage/load-balancing.md
+++ b/src/main/paradox/usage/load-balancing.md
@@ -18,6 +18,17 @@ Java
 Scala
 : @@snip [LoadBalancing.scala](../resources/LoadBalancing.scala) { #round_robin }
 
+By default, update requests are also load balanced. To send update requests to shard leaders,
+you should set `isUpdatesToLeaders = true`. Then still the `isSendToLeaders` property of the update request (default `true`) will be taken into account, i.e. if this would be `false`, then the update request would be load balanced round robin.
+In other words, only if both `RoundRobinLB.isUpdatesToLeaders` and `IsUpdateRequest.isSendToLeaders` are `true`, the
+update request will be sent to the shard leader.
+
+Java
+: @@snip [LoadBalancing.java](../resources/LoadBalancing.java) { #round_robin_update_to_leader }
+
+Scala
+: @@snip [LoadBalancing.scala](../resources/LoadBalancing.scala) { #round_robin_update_to_leader }
+
 ### Fastest Server Load Balancer
 
 The `FastestServerLB` is a statistics based load balancer that classifies servers as "fast" and "slow" servers (based on
@@ -50,6 +61,8 @@ This can be overridden with `initialTestRuns`.
 @@@ note { title=Hint }
 `FastestServerLB` also exports stats via JMX (under object name `io.ino.solrs:type=FastestServerLB`), in case you're interested in this.
 @@@
+
+Similarly as for `RoundRobinLB`, with `isUpdatesToLeaders` you can configure the `FastestServerLB` to send updates to leaders if `IsUpdateRequest.isSendToLeaders` is set to `true` as well.
 
 Here's  a code sample of the `FastestServerLB`:
 


### PR DESCRIPTION
The previous behavior was that all updates were sent to the shard leader, which is now changed, and where the previous behavior can be re-established via `isUpdatesToLeaders`.

Updates now are sent to the shard leader, if
`RoundRobinLB`/`FastestServerLB.isUpdatesToLeaders` is set to `true` _and_ if also `IsUpdateRequest.isSendToLeaders` is set to `true` (which is the default).

This should match intuitive expectations better and is also aligned with [CloudSolrClient.isUpdatesToLeaders](https://solr.apache.org/docs/9_3_0/solrj/org/apache/solr/client/solrj/impl/CloudSolrClient.html#isUpdatesToLeaders()).

Refs #116