### PR TITLE
Add test showing basic auth usage

### DIFF
--- a/src/test/resources/solr-basic-auth/collection1
+++ b/src/test/resources/solr-basic-auth/collection1
@@ -1,0 +1,1 @@
+../solr/collection1/

--- a/src/test/resources/solr-basic-auth/security.json
+++ b/src/test/resources/solr-basic-auth/security.json
@@ -1,0 +1,12 @@
+{
+  "authentication":{
+    "blockUnknown": true,
+    "class":"solr.BasicAuthPlugin",
+    "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="}
+  },
+  "authorization":{
+    "class":"solr.RuleBasedAuthorizationPlugin",
+    "permissions":[{"name":"security-edit", "role":"admin"}],
+    "user-role":{"solr":"admin"}
+  }
+}

--- a/src/test/resources/solr-basic-auth/server-enabled.txt
+++ b/src/test/resources/solr-basic-auth/server-enabled.txt
@@ -1,0 +1,1 @@
+../solr/server-enabled.txt

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientBasicAuthCloudIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientBasicAuthCloudIntegrationSpec.scala
@@ -1,0 +1,118 @@
+package io.ino.solrs
+
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.impl.CloudSolrClient
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.asynchttpclient.Realm
+import org.asynchttpclient.Realm.AuthScheme
+import org.scalatest.Assertion
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.PatienceConfiguration.Interval
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.slf4j.LoggerFactory
+
+import java.nio.file.Paths
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+//noinspection RedundantDefaultArgument
+class AsyncSolrClientBasicAuthCloudIntegrationSpec extends StandardFunSpec with Eventually with IntegrationPatience {
+
+  private implicit val timeout: FiniteDuration = 5.second
+
+  private var solrRunner: SolrCloudRunner = _
+  private def solrServerUrls = solrRunner.solrCoreUrls
+
+  private var solrServers: CloudSolrServers[Future] = _
+  private var cut: AsyncSolrClient[Future] = _
+  private var solrJClient: CloudSolrClient = _
+
+  private val collection1 = "collection1"
+
+  private val q = new SolrQuery("*:*").setRows(1000)
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  import io.ino.solrs.SolrUtils._
+
+  override def beforeEach(): Unit = {
+    solrRunner = SolrCloudRunner.start(
+      numServers = 2,
+      collections = List(SolrCollection(collection1, replicas = 2, shards = 1)),
+      defaultCollection = Some(collection1),
+      // read from src/test/resources, because sbt might not copy the symlink solr/collection1/conf when copying to target...
+      maybeSolrHome = Some(Paths.get("./src/test/resources/solr-basic-auth").toAbsolutePath.normalize())
+    )
+    solrJClient = solrRunner.solrJClient
+
+    eventually(Timeout(10 seconds)) {
+      solrJClient.deleteByQuery("*:*")
+    }
+    solrJClient.commit()
+
+    solrJClient.add(someDocsAsJList)
+    solrJClient.commit()
+
+    // Check that indexed data is available
+    queryAndCheckResponse()
+  }
+
+  private def queryAndCheckResponse(): Unit = {
+    eventually(Timeout(2 seconds), Interval(50 milliseconds)) {
+      getIds(solrJClient.query(q)) should contain theSameElementsAs someDocsIds
+    }
+  }
+
+  override def afterEach(): Unit = {
+    solrJClient.close()
+    cut.shutdown()
+    solrServers.shutdown()
+    solrRunner.shutdown()
+  }
+
+  describe("AsyncSolrClient with CloudSolrServers") {
+
+    it("should support basic auth with a configured http client") {
+
+      val httpClient = {
+        val config = new DefaultAsyncHttpClientConfig.Builder()
+        val realm = new Realm.Builder(securityJson.username, securityJson.password)
+          .setUsePreemptiveAuth(true)
+          .setScheme(AuthScheme.BASIC)
+          .build()
+        new DefaultAsyncHttpClient(config.setRealm(realm).build)
+      }
+
+      solrServers = new CloudSolrServers(
+        solrRunner.zkAddress,
+        clusterStateUpdateInterval = 100 millis,
+        defaultCollection = Some(collection1))
+
+      // We need to configure a retry policy as otherwise requests fail because server status is not
+      // updated fast enough...
+      cut = AsyncSolrClient
+        .Builder(RoundRobinLB(solrServers))
+        .withRetryPolicy(RetryPolicy.TryAvailableServers)
+        .withHttpClient(httpClient)
+        .build
+
+      awaitAllServersBeingEnabled()
+
+      eventually {
+        await(cut.query(collection1, q).map(getIds)) should contain theSameElementsAs someDocsIds
+      }
+    }
+
+  }
+
+  private def awaitAllServersBeingEnabled(): Assertion = {
+    eventually(Timeout(30 seconds), Interval(100 milliseconds)) {
+      logger.info("Awaiting all servers status is Enabled")
+      cut.loadBalancer.solrServers.all.map(_.status) should contain theSameElementsAs solrServerUrls.map(_ => Enabled)
+    }
+  }
+
+}

--- a/src/test/scala/io/ino/solrs/AsyncSolrClientBasicAuthIntegrationSpec.scala
+++ b/src/test/scala/io/ino/solrs/AsyncSolrClientBasicAuthIntegrationSpec.scala
@@ -1,0 +1,85 @@
+package io.ino.solrs
+
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.impl.Http2SolrClient
+import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
+import org.asynchttpclient.Realm
+import org.asynchttpclient.Realm.AuthScheme
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.concurrent.IntegrationPatience
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Arrays.asList
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class AsyncSolrClientBasicAuthIntegrationSpec extends StandardFunSpec with Eventually with IntegrationPatience {
+
+  private var solrs: AsyncSolrClient[Future] = _
+
+  private var solrRunner: SolrRunner = _
+  private var solrJClient: Http2SolrClient = _
+
+  private val collection1 = "collection1"
+
+  import io.ino.solrs.SolrUtils._
+
+  override def beforeAll(): Unit = {
+    solrRunner = SolrRunner.start(
+      port = 8889,
+      // read from src/test/resources, because sbt might not copy the symlink solr/collection1/conf when copying to target...
+      maybeSolrHome = Some(Paths.get("./src/test/resources/solr-basic-auth").toAbsolutePath.normalize())
+    )
+    solrJClient = new Http2SolrClient.Builder("http://localhost:" + solrRunner.port + "/solr/collection1")
+      .withBasicAuthCredentials("solr", "SolrRocks") // from https://solr.apache.org/guide/8_10/basic-authentication-plugin.html
+      .build()
+  }
+
+  override def beforeEach(): Unit = {
+    eventually {
+      solrJClient.deleteByQuery("*:*")
+    }
+    val doc1 = newInputDoc("id1", "doc1", "cat1", 10)
+    val doc2 = newInputDoc("id2", "doc2", "cat1", 20)
+    solrJClient.add(asList(doc1, doc2))
+    solrJClient.commit()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    solrs.shutdown()
+    solrJClient.close()
+    solrRunner.stop()
+  }
+
+  describe("Solr") {
+
+    it("should support basic auth with a configured http client") {
+
+      val httpClient = {
+        val config = new DefaultAsyncHttpClientConfig.Builder()
+        val realm = new Realm.Builder(securityJson.username, securityJson.password)
+          .setUsePreemptiveAuth(true)
+          .setScheme(AuthScheme.BASIC)
+          .build()
+        new DefaultAsyncHttpClient(config.setRealm(realm).build)
+      }
+
+      solrs = AsyncSolrClient.Builder(s"http://localhost:${solrRunner.port}/solr/collection1")
+        .withHttpClient(httpClient)
+        .build
+
+      val response = solrs.query(new SolrQuery("cat:cat1"))
+
+      await(response)(1.second).getResults.getNumFound should be (2)
+    }
+
+  }
+
+}

--- a/src/test/scala/io/ino/solrs/package.scala
+++ b/src/test/scala/io/ino/solrs/package.scala
@@ -1,0 +1,10 @@
+package io.ino
+
+package object solrs {
+
+  object securityJson {
+    val username = "solr"
+    val password = "SolrRocks"
+  }
+
+}


### PR DESCRIPTION
This works by configuring a custom http client:

```scala
val httpClient = {
  val config = new DefaultAsyncHttpClientConfig.Builder()
  val realm = new Realm.Builder(username, password)
    .setUsePreemptiveAuth(true)
    .setScheme(AuthScheme.BASIC)
    .build()
  new DefaultAsyncHttpClient(config.setRealm(realm).build)
}

val solr: AsyncSolrClient[Future] = AsyncSolrClient.Builder(s"http://localhost:${solrRunner.port}/solr/collection1")
  .withHttpClient(httpClient)
  .build
```

Refs #123