### PR TITLE
Change publishing to central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,11 +94,9 @@ paradoxMaterialTheme in Compile := {
 
 // Publish settings
 ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+  val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+  else localStaging.value
 }
 
 ThisBuild / versionScheme := Some("early-semver")


### PR DESCRIPTION
See also
* https://central.sonatype.org/news/20250326_ossrh_sunset/
* https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
* https://github.com/sbt/sbt/releases/tag/v1.11.0
* https://www.scala-sbt.org/release/docs/Using-Sonatype.html